### PR TITLE
Add develop branch to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script: "python setup.py test"
 branches:
     only:
         - master
+        - develop
 notifications:
   slack:
     secure: fbsAu4oLvRWKGpPLzJcjobftOK1bOjmvjkrJbQ2+QcrpWqhsU0oSrBr4812zOQBbtU3LkyAgOYOMeKtIqkxaUaZed+73Lv69ZpdBpzx0tY9Oj5Qm/sUYd8g2NjYnK3GpbSp3rK0CVMIhVAopM14GYqWTAoCLCeyDw5jNnx9gLW0AQN35dozKH0kEdp/q2kMt3vsd8/hauJjtiYsBzlIh4s+92qZiYgKkHzqvX27KUfwWNXve18QxYKlzldApVtmstm0J2o+tV8Wzx3x9FBSWJK40pXjVT/KEdWEdCLnh85ZtzEdRc7sRThDBKxQBuGkGm78a4pD5fj7imM7eVR9mQK9+nl1JJ/BOVwIz1ij7kF9Kl8WnGZkfU0W5eRwaJMXHv9ohP3yXXccloAjCHPS+Dr9nGeFNQKuGSTj2Pd9NDPhKh350hB1qA4cIu9uerrcHZEaSab0Ethc5xHPELZQXPmnthuPPlRSoCTaO9G2RKp07KdiTaC6UGUw9rkzaJEmTQU9Xzcpog3AdO/cBVQ7EMsWyPSQqn8vk9QO8Sj47h009IE4UzBbkfnDW2QYzv0LOgC8IvAdfuL6yo2ljATqFz9ppbPGnNEQA+FpBiuJKO/yI8k2NPLtKKQ5G9xPVriXwD0OMeMGLQk+yRrXmF3bOZ40b8eNpH/8AkwV1QgYsKBU=


### PR DESCRIPTION
Now that we are requiring PRs to branch off of `develop`, we need to add `develop` to the Travis configuration YAML to trigger PR builds.