### PR TITLE
Remove six as a dependency and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pytest --cov-report html:htmlcov
 
 External dependencies are listed in `requirements.txt` and can be installed
 with `pip` (see [Installation instructions][0]) or manually. The dependencies
-on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`][1]. 
+`beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`][1]. 
 Developers additionally need [`pytest`][2] and are encouraged to use 
 [`pylint`][3], [`pycodestyle`][4], [`pydocstyle`][5] and [`yapf`][6] for
 proper code formatting.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pytest --cov-report html:htmlcov
 
 ## Dependencies
 
-External dependencies are listed in `requirements.txt` and can be installed with `pip` as outlined in the [Installation instructions](#installation-instructions) or manually. The dependencies on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies).
+External dependencies are listed in `requirements.txt` and can be installed with `pip` as outlined in the [Installation instructions](#installation-instructions) or manually. The dependencies on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies). Developers need additionally [`pytest`](https://docs.pytest.org) and are encouraged to use tools such as [`pylint`](https://pylint.readthedocs.io), [`pycodestyle`](http://pycodestyle.pycqa.org) [`pydocstyle`](http://www.pydocstyle.org) and [`yapf`](https://github.com/google/yapf) for proper code formatting.
 
 ## Code Style Guide
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ with line-by-line highlighting:
 pytest --cov-report html:htmlcov
 ```
 
+## Dependencies
+
+External dependencies are listed in `requirements.txt` and can be installed with `pip` as outlined in the [Installation instructions](#installation-instructions) or manually. The dependencies on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies).
+
 ## Code Style Guide
 
 Use [google standards](https://google.github.io/styleguide/pyguide.html)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Use [google standards](https://google.github.io/styleguide/pyguide.html)
 * Use `pylint` from command line (as in style guide)
 
 ## Copyright Notice
+
 Becquerel v. 0.1, Copyright (c) 2017, The Regents of the University of
 California (UC), through Lawrence Berkeley National Laboratory, and the UC
 Berkeley campus (subject to receipt of any required approvals from the U.S.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pytest --cov-report html:htmlcov
 
 ## Dependencies
 
-External dependencies are listed in `requirements.txt` and can be installed with `pip` as outlined in the [Installation instructions](#installation-instructions) or manually. The dependencies on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies). Developers need additionally [`pytest`](https://docs.pytest.org) and are encouraged to use tools such as [`pylint`](https://pylint.readthedocs.io), [`pycodestyle`](http://pycodestyle.pycqa.org) [`pydocstyle`](http://www.pydocstyle.org) and [`yapf`](https://github.com/google/yapf) for proper code formatting.
+External dependencies are listed in `requirements.txt` and can be installed with `pip` as outlined in the [Installation instructions](#installation-instructions) or manually. The dependencies on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies). Developers additionally need [`pytest`](https://docs.pytest.org) and are encouraged to use tools such as [`pylint`](https://pylint.readthedocs.io), [`pycodestyle`](http://pycodestyle.pycqa.org) [`pydocstyle`](http://www.pydocstyle.org) and [`yapf`](https://github.com/google/yapf) for proper code formatting.
 
 ## Code Style Guide
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,20 @@ pytest --cov-report html:htmlcov
 
 ## Dependencies
 
-External dependencies are listed in `requirements.txt` and can be installed with `pip` as outlined in the [Installation instructions](#installation-instructions) or manually. The dependencies on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`](https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies). Developers additionally need [`pytest`](https://docs.pytest.org) and are encouraged to use tools such as [`pylint`](https://pylint.readthedocs.io), [`pycodestyle`](http://pycodestyle.pycqa.org) [`pydocstyle`](http://www.pydocstyle.org) and [`yapf`](https://github.com/google/yapf) for proper code formatting.
+External dependencies are listed in `requirements.txt` and can be installed
+with `pip` (see [Installation instructions][0]) or manually. The dependencies
+on `beautifulsoup4`, `lxml` and `html5lib` are necessary for [`pandas`][1]. 
+Developers additionally need [`pytest`][2] and are encouraged to use 
+[`pylint`][3], [`pycodestyle`][4], [`pydocstyle`][5] and [`yapf`][6] for
+proper code formatting.
+
+[0]: #installation-instructions
+[1]: https://pandas.pydata.org/pandas-docs/stable/install.html#dependencies
+[2]: https://docs.pytest.org
+[3]: https://pylint.readthedocs.io
+[4]: http://pycodestyle.pycqa.org
+[5]: http://www.pydocstyle.org
+[6]: https://github.com/google/yapf
 
 ## Code Style Guide
 
@@ -66,7 +79,16 @@ Use [google standards](https://google.github.io/styleguide/pyguide.html)
 * Use `pylint` from command line (as in style guide)
 
 ## Copyright Notice
-Becquerel v. 0.1, Copyright (c) 2017, The Regents of the University of California (UC), through Lawrence Berkeley National Laboratory, and the UC Berkeley campus (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights reserved.
-If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships Office at  IPO@lbl.gov.
+Becquerel v. 0.1, Copyright (c) 2017, The Regents of the University of
+California (UC), through Lawrence Berkeley National Laboratory, and the UC
+Berkeley campus (subject to receipt of any required approvals from the U.S.
+Dept. of Energy). All rights reserved. If you have questions about your rights
+to use or distribute this software, please contact Berkeley Lab's Innovation &
+Partnerships Office at  IPO@lbl.gov.
 
-NOTICE.  This Software was developed under funding from the U.S. Department of Energy and the U.S. Government consequently retains certain rights.  As such, the U.S. Government has been granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
+NOTICE.  This Software was developed under funding from the U.S. Department of
+Energy and the U.S. Government consequently retains certain rights.  As such,
+the U.S. Government has been granted for itself and others acting on its
+behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+to reproduce, distribute copies to the public, prepare derivative works, and
+perform publicly and display publicly, and to permit other to do so.

--- a/becquerel/core/energycal.py
+++ b/becquerel/core/energycal.py
@@ -1,7 +1,7 @@
 """"Energy calibration classes"""
 
 from abc import ABCMeta, abstractmethod, abstractproperty
-from builtins import dict, super, zip  # pylint: disable=redefined-builtin
+from future.builtins import dict, super, zip
 from future.utils import viewitems
 import numpy as np
 

--- a/becquerel/core/utils.py
+++ b/becquerel/core/utils.py
@@ -3,11 +3,24 @@
 from __future__ import print_function
 import datetime
 from dateutil.parser import parse as dateutil_parse
-from six import string_types
 from uncertainties import UFloat, unumpy
 import numpy as np
 
 VECTOR_TYPES = (list, tuple, np.ndarray)
+
+try:
+
+    isinstance("", basestring)
+
+    def isstring(s):
+        """Test for strings in python2 and 3"""
+        return isinstance(s, basestring)
+
+except NameError:
+
+    def isstring(s):
+        """Test for strings in python2 and 3"""
+        return isinstance(s, str)
 
 
 class UncertaintiesError(Exception):
@@ -94,7 +107,7 @@ def handle_datetime(input_time, error_name='datetime arg', allow_none=False):
 
     if isinstance(input_time, datetime.datetime):
         return input_time
-    elif isinstance(input_time, string_types):
+    elif isstring(input_time):
         return dateutil_parse(input_time)
     elif input_time is None and allow_none:
         return None

--- a/becquerel/core/utils.py
+++ b/becquerel/core/utils.py
@@ -13,13 +13,13 @@ try:
     isinstance("", basestring)
 
     def isstring(s):
-        """Test for strings in python2 and 3"""
+        """Test for strings in python2"""
         return isinstance(s, basestring)
 
 except NameError:
 
     def isstring(s):
-        """Test for strings in python2 and 3"""
+        """Test for strings in python3"""
         return isinstance(s, str)
 
 

--- a/becquerel/tools/isotope.py
+++ b/becquerel/tools/isotope.py
@@ -1,7 +1,7 @@
 """Nuclear isotopes and isomers."""
 
 from __future__ import print_function
-from builtins import super
+from future.builtins import super
 import numpy as np
 import uncertainties
 from . import element

--- a/becquerel/tools/isotope_qty.py
+++ b/becquerel/tools/isotope_qty.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 import datetime
-from six import string_types
 import copy
 import numpy as np
 from .isotope import Isotope
@@ -34,7 +33,7 @@ def handle_isotope(isotope, error_name=None):
 
     if isinstance(isotope, Isotope):
         return isotope
-    elif isinstance(isotope, string_types):
+    elif utils.isstring(isotope):
         return Isotope(isotope)
     else:
         raise TypeError(

--- a/becquerel/tools/materials.py
+++ b/becquerel/tools/materials.py
@@ -11,9 +11,8 @@ from __future__ import print_function
 from collections import Iterable
 import requests
 import pandas as pd
-from six import string_types
 from .element import element_symbol
-
+from ..core.utils import isstring
 
 MAX_Z = 92
 N_COMPOUNDS = 48
@@ -111,7 +110,7 @@ def convert_composition(comp):
         raise NISTMaterialsRequestError(
             'Compound must be an iterable of strings: {}'.format(comp))
     for line in comp:
-        if not isinstance(line, string_types):
+        if not isstring(line):
             raise NISTMaterialsRequestError(
                 'Line must be a string type: {} {}'.format(line, type(line)))
         try:

--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -12,9 +12,8 @@ from builtins import super
 import numpy as np
 import requests
 import pandas as pd
-from six import string_types
 import uncertainties
-
+from ..core.utils import isstring
 
 PARITIES = ['+', '-', 'ANY']
 
@@ -201,9 +200,9 @@ def _parse_float_uncertainty(x, dx):
 
     """
 
-    if not isinstance(x, string_types):
+    if not isstring(x):
         raise NNDCRequestError('Value must be a string: {}'.format(x))
-    if not isinstance(dx, string_types):
+    if not isstring(dx):
         raise NNDCRequestError('Uncertainty must be a string: {}'.format(dx))
     # ignore percents
     if '%' in x:

--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -8,7 +8,7 @@ References:
 """
 
 from __future__ import print_function
-from builtins import super
+from future.builtins import super
 import numpy as np
 import requests
 import pandas as pd

--- a/becquerel/tools/wallet_cache.py
+++ b/becquerel/tools/wallet_cache.py
@@ -1,7 +1,7 @@
 """A cache of all NNDC wallet card data."""
 
 from __future__ import print_function
-from builtins import super
+from future.builtins import super
 import pandas as pd
 import uncertainties
 from . import nndc

--- a/becquerel/tools/wallet_cache.py
+++ b/becquerel/tools/wallet_cache.py
@@ -3,10 +3,10 @@
 from __future__ import print_function
 from builtins import super
 import pandas as pd
-from six import string_types
 import uncertainties
 from . import nndc
 from . import df_cache
+from ..core.utils import isstring
 
 # pylint: disable=no-self-use
 
@@ -18,7 +18,7 @@ def convert_float_ufloat(x):
       x: a string giving the number
     """
 
-    if isinstance(x, string_types):
+    if isstring(x):
         if '+/-' in x:
             tokens = x.split('+/-')
             return uncertainties.ufloat(float(tokens[0]), float(tokens[1]))

--- a/becquerel/tools/xcom.py
+++ b/becquerel/tools/xcom.py
@@ -13,9 +13,8 @@ from __future__ import print_function
 from collections import Iterable
 import requests
 import pandas as pd
-from six import string_types
 from . import element
-
+from ..core.utils import isstring
 
 # Dry air relative weights taken from:
 # http://www.engineeringtoolbox.com/air-composition-d_212.html
@@ -203,7 +202,7 @@ class _XCOMQuery(object):
     @staticmethod
     def _argument_type(arg):
         """Determine if argument is a symbol, Z, compound, or mixture."""
-        if isinstance(arg, string_types):
+        if isstring(arg):
             if arg.isdigit():
                 return {'z': arg}
             elif arg.lower() in [s.lower() for s in element.SYMBOLS]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest>=3.0.0
 pytest-cov
+pytest-runner

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 pytest>=3.0.0
 pytest-cov
-pytest-runner

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ python-dateutil
 requests
 scipy
 setuptools
-six
 uncertainties

--- a/tests/isotope_qty_test.py
+++ b/tests/isotope_qty_test.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import datetime
 from dateutil.parser import parse as dateutil_parse
-from six import string_types
 import copy
 import numpy as np
 from uncertainties import ufloat
@@ -13,6 +12,7 @@ from becquerel.tools.isotope_qty import NeutronIrradiationError
 from becquerel.tools.isotope_qty import decay_normalize
 from becquerel.tools.isotope_qty import decay_normalize_spectra
 from becquerel import Spectrum
+import becquerel as bq
 import pytest
 
 
@@ -128,7 +128,7 @@ def test_isotopequantity_ref_date_rad(radioisotope, iq_date):
     iq = IsotopeQuantity(radioisotope, date=iq_date, atoms=1e24)
     if isinstance(iq_date, datetime.datetime):
         assert iq.ref_date == iq_date
-    elif isinstance(iq_date, string_types):
+    elif bq.core.utils.isstring(iq_date):
         assert iq.ref_date == dateutil_parse(iq_date)
     else:
         assert (datetime.datetime.now() - iq.ref_date).total_seconds() < 5
@@ -140,7 +140,7 @@ def test_isotopequantity_ref_date_stable(stable_isotope, iq_date):
     iq = IsotopeQuantity(stable_isotope, date=iq_date, atoms=1e24)
     if isinstance(iq_date, datetime.datetime):
         assert iq.ref_date == iq_date
-    elif isinstance(iq_date, string_types):
+    elif bq.core.utils.isstring(iq_date):
         assert iq.ref_date == dateutil_parse(iq_date)
     else:
         assert (datetime.datetime.now() - iq.ref_date).total_seconds() < 5


### PR DESCRIPTION
This addresses issue #127.
- [x] Removed six as a dependency and created a small helper function `isstring` for checking if something is a string.
- [x] Add dependencies section to readme
- [x] Change `builtins` imports to `future.builtins`
- [x] Add `pytest-runner` to requirements-dev.txt (required at least on Fedora).