### PR TITLE
Spectrum bugfixes

### DIFF
--- a/becquerel/__init__.py
+++ b/becquerel/__init__.py
@@ -7,6 +7,7 @@ from .__metadata__ import __description__, __url__
 from .__metadata__ import __version__, __license__, __copyright__
 
 from .core.spectrum import Spectrum, SpectrumError, UncalibratedError
+from .core.spectrum import SpectrumWarning
 from .core.energycal import LinearEnergyCal, EnergyCalError, BadInput
 from .core.utils import UncertaintiesError
 from .core.plotting import SpectrumPlotter, PlottingError
@@ -15,9 +16,9 @@ from .core.peakfinder import (PeakFilter, PeakFilterError, BoxcarPeakFilter,
 from .core.autocal import AutoCalibrator, AutoCalibratorError
 
 __all__ = ['core', 'parsers', 'tools',
-           'Spectrum', 'SpectrumError', 'SpectrumPlotter', 'PlottingError',
-           'UncalibratedError', 'LinearEnergyCal', 'EnergyCalError',
-           'BadInput', 'UncertaintiesError',
+           'Spectrum', 'SpectrumError', 'SpectrumWarning', 'SpectrumPlotter',
+           'PlottingError', 'UncalibratedError', 'LinearEnergyCal',
+           'EnergyCalError', 'BadInput', 'UncertaintiesError',
            'PeakFilter', 'PeakFilterError', 'BoxcarPeakFilter',
            'GaussianPeakFilter', 'PeakFinder', 'PeakFinderError',
            'AutoCalibrator', 'AutoCalibratorError',

--- a/becquerel/core/plotting.py
+++ b/becquerel/core/plotting.py
@@ -166,12 +166,12 @@ class SpectrumPlotter(object):
         """
 
         if mode is None:
-            if self.spec.counts is not None:
+            if self.spec._counts is not None:
                 self._ymode = 'counts'
             else:
                 self._ymode = 'cps'
         elif mode.lower() in ('count', 'counts', 'cnt', 'cnts'):
-            if self.spec.counts is None:
+            if self.spec._counts is None:
                 raise PlottingError('Spectrum has counts not defined')
             self._ymode = 'counts'
         elif mode.lower() == 'cps':

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -135,8 +135,13 @@ class Spectrum(object):
         if counts is not None:
             if len(counts) == 0:
                 raise SpectrumError('Empty spectrum counts')
+            if uncs is None and np.any(counts < 0):
+                raise SpectrumError('Negative values in counts, most likely ' +
+                                    'non-Poissonian uncertainties. Please' +
+                                    'provide uncs to force initializiation.')
             self._counts = handle_uncs(
                 counts, uncs, lambda x: np.maximum(np.sqrt(x), 1))
+
             self._cps = None
         else:
             if len(cps) == 0:

--- a/becquerel/core/utils.py
+++ b/becquerel/core/utils.py
@@ -78,7 +78,7 @@ def handle_uncs(x_array, x_uncs, default_unc_func):
     ufloats = all_ufloats(x_array)
 
     if ufloats and x_uncs is None:
-        return np.array(x_array)
+        return np.asarray(x_array)
     elif ufloats:
         raise UncertaintiesError('Specify uncertainties with UFloats or ' +
                                  'by separate argument, but not both')

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ addopts = --cov=becquerel --cov-report term --cov-report html:htmlcov -m "not pl
 markers =
     webtest: test requires internet connection
     plottest: test will produce plot figures
+filterwarnings = always

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -156,8 +156,8 @@ def test_uncalibrated_exception(uncal_spec):
 
 
 def test_negative_input(spec_data):
-    """Make sure negative values in counts cause an error,
-       and that with uncs provided no error appears."""
+    """Make sure negative values in counts throw an exception,
+       and exception is not raised if uncs are provided."""
 
     neg_spec = spec_data[:]
     neg_spec[::2] *= -1
@@ -511,6 +511,7 @@ def test_add_sub_cps(type1, type2, lt1, lt2):
     assert diff.livetime is None
     assert np.all(diff.cps_vals == spec1.cps_vals - spec2.cps_vals)
 
+
 @pytest.mark.parametrize('type1, type2, lt1, lt2', [
     ('uncal', 'uncal_cps', None, None),
     ('uncal_cps', 'uncal', None, None),
@@ -526,6 +527,7 @@ def test_adddition_errors(type1, type2, lt1, lt2):
 
     with pytest.raises(bq.SpectrumError):
         tot = spec1 + spec2
+
 
 @pytest.mark.parametrize('lt1, lt2', [
     (300, 600),
@@ -555,7 +557,7 @@ def test_subtract_counts(type1, type2, lt1, lt2):
     ('uncal', 'uncal_cps', 300, None),
     ('uncal_cps', 'uncal', None, 300)])
 def test_subtract_errors(type1, type2, lt1, lt2):
-    """Test errors/warings during subtract of mixed spectra"""
+    """Test errors/warnings during subtraction of mixed spectra"""
 
     spec1, spec2 = (get_spectrum(type1, lt=lt1),
                     get_spectrum(type2, lt=lt2))
@@ -566,7 +568,7 @@ def test_subtract_errors(type1, type2, lt1, lt2):
         with pytest.warns(bq.SpectrumWarning):
             diff = spec1 - spec2
         assert diff.livetime is None
-        #assert np.all(diff.cps_vals == spec1.cps_vals - spec2.cps_vals)
+
 
 # ----------------------------------------------
 #  Test multiplication and division of spectra

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -155,6 +155,22 @@ def test_uncalibrated_exception(uncal_spec):
         uncal_spec.energies_kev
 
 
+def test_negative_input(spec_data):
+    """Make sure negative values in counts cause an error,
+       and that with uncs provided no error appears."""
+
+    neg_spec = spec_data[:]
+    neg_spec[::2] *= -1
+    neg_uncs = np.where(neg_spec < 0, np.nan, 1)
+
+    with pytest.raises(bq.SpectrumError):
+        spec = bq.Spectrum(neg_spec)
+
+    spec = bq.Spectrum(neg_spec, uncs=neg_uncs)
+    assert np.any(spec.counts_vals < 0)
+    assert np.any(np.isnan(spec.counts_uncs))
+
+
 # ----------------------------------------------
 #      Test Spectrum livetime properties
 # ----------------------------------------------


### PR DESCRIPTION
Closes #140 
Closes #122 
Closes #113 
Closes #112 

To do:
- [x] If livetime not provided it should be always `None` (#140)
- [x] Allow for counts from cps and livetime (#122)
- [x] Behavior of addition and subtraction and raise warnings when necessary (#112)
- [x] Negative input to spectrum (#113)
- [x] Fix tests for new behavior
- [x] Add new tests, remove unnecessary tests
- [x] Fix doc strings
- [x] lints, spell check

Remarks:
 * Addition: Only allowed it if both spectrum were initiated identically with `counts` or `cps`, respectively. If this is not the case the user can enforce addition with `Spectrum(counts=specA.counts+specB.counts)` or `Spectrum(cps=specA.cps+specB.cps)` as suggested in the error message.
    * Question: Should a warning be raised if `counts` were added and `livetime` have been ignored (because one of them was `None`)?
* Subtraction: If `cps` is available in both subtract `cps` and create a new spectrum with `cps`. If one of the `cps` values has been derived from `counts` and `livetime` it raises a warning. If `cps` is not available in one of the spectra try subtraction of `counts` and set `uncs` to `np.nan`; this always raises a warning.
    * Question: if `counts`-subtraction fails it fails with a ''Unknown livetime; cannot calculate counts from CPS" `SpectrumError`, should we raise a special subtraction failed error message?