### PR TITLE
Ignore pytest warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,9 @@ addopts = --cov=becquerel --cov-report term --cov-report html:htmlcov -m "not pl
 markers =
     webtest: test requires internet connection
     plottest: test will produce plot figures
-filterwarnings = always
+filterwarnings =
+    always
+    ; Not fixing the problem: https://github.com/pytest-dev/pytest/pull/3613
+    ignore:.*t resolve package from __spec__ or __package__.*:ImportWarning
+    ; uncertainties, see: https://github.com/lebigot/uncertainties/pull/88
+    ignore:.*getargspec.*:DeprecationWarning


### PR DESCRIPTION
This **patches** two warning which persist during testing:

- py3 `__spec__` issue
  - Actual resolution unknown currently, see #150
- A warning from uncertainties using a deprecated call
  - Actual resolution in a PR I've submitted: https://github.com/lebigot/uncertainties/pull/88