### PR TITLE
Release 0.2.1

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@
 
 *** Copyright Notice ***
 
-Becquerel v. 0.2.0, Copyright (c) 2017, The Regents of the University of California (UC), through Lawrence Berkeley National Laboratory, and the UC Berkeley campus (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights reserved.
+Becquerel v. 0.2.1, Copyright (c) 2017, The Regents of the University of California (UC), through Lawrence Berkeley National Laboratory, and the UC Berkeley campus (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights reserved.
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships Office at  IPO@lbl.gov.
 
 NOTICE.  This Software was developed under funding from the U.S. Department of Energy and the U.S. Government consequently retains certain rights.  As such, the U.S. Government has been granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, prepare derivative works, and perform publicly and display publicly, and to permit other to do so.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include MANIFEST.in
+include *.txt
+include *.md
+include *.cfg

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you are interested in contributing, please see the guidelines in [`CONTRIBUTI
 
 ## Copyright Notice
 
-Becquerel v. 0.2.0, Copyright (c) 2017, The Regents of the University of
+Becquerel v. 0.2.1, Copyright (c) 2017, The Regents of the University of
 California (UC), through Lawrence Berkeley National Laboratory, and the UC
 Berkeley campus (subject to receipt of any required approvals from the U.S.
 Dept. of Energy). All rights reserved. If you have questions about your rights

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,11 @@
-## Release checklist
+## 1. Create Tagged Release
 
-- [ ] Branch off of `develop` and name the branch `release-X.X.X`
+We follow the `git flow` [release process](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+
+- If normal release:
+  - [ ] Branch off of `develop` and name the branch `release-X.X.X`
+- If hotfix/patch:
+  - [ ] Branch off of `master` and name the branch `hotfix-X`
 - [ ] Update version number within the repository
   - in `setup.py`
   - in Copyright Notice in `README`
@@ -11,6 +16,9 @@
 - [ ] Approve PR and merge it into master, but do not delete it yet
 - [ ] Create tagged version (`X.X.X`) on GitHub
 - [ ] Add release notes to the tag on GitHub with a list of changes
+
+## 2. Distribution Creation/Upload
+
 - [ ] Create distribution
   ```bash
   git pull
@@ -35,5 +43,8 @@
   python3 -m pip install becquerel
   python3 -c "import becquerel; print(becquerel.__version__)"
   ```
-- [ ] Create PR from `release-X.X.X` into `develop`
-- [ ] After PR is accepted, delete the `release-X.X.X` branch
+
+## 3. Cleanup
+
+- [ ] Create PR from the `release-X.X.X`/`hotfix-X` branch into `develop`
+- [ ] After PR is accepted, delete the `release-X.X.X`/`hotfix-X` branch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,14 +10,26 @@
 - [ ] Commit the changes, push to GitHub, and start a pull request into `master`
 - [ ] After PR is accepted, create tagged version (`X.X.X`) on GitHub
 - [ ] Add release notes to the tag on GitHub with a list of changes
+- [ ] Create distribution
+  ```bash
+  python3 -m pip install --user --upgrade setuptools wheel
+  python3 setup.py sdist bdist_wheel --universal
+  ```
+- [ ] Test distribution
+  ```bash
+  python3 -m pip install dist/becquerel-<version>-py2.py3-none-any.whl
+  python3 -m pip install dist/becquerel-<version>.tar.gz
+  ```
 - [ ] Upload new version to PyPI
-  - `python3 -m pip install --user --upgrade setuptools wheel`
-  - `python3 setup.py sdist bdist_wheel --universal`
-  - `python3 -m pip install --user --upgrade twine`
-  - `python3 -m twine upload dist/*`
+  ```bash
+  python3 -m pip install --user --upgrade twine
+  python3 -m twine upload dist/becquerel-<version>*
+  ```
 - [ ] Test new version installs from PyPI
-  - `cd ..`
-  - `python3 -m pip install becquerel`
-  - `python3 -c "import becquerel; print(becquerel.__version__)"`
+  ```bash
+  cd ..
+  python3 -m pip install becquerel
+  python3 -c "import becquerel; print(becquerel.__version__)"
+  ```
 - [ ] Create PR from `release-X.X.X` into `develop`
 - [ ] After PR is accepted, delete the `release-X.X.X` branch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@
 - [ ] Add release notes to the tag on GitHub with a list of changes
 - [ ] Upload new version to PyPI
   - `python3 -m pip install --user --upgrade setuptools wheel`
-  - `python3 setup.py sdist bdist_wheel`
+  - `python3 setup.py sdist bdist_wheel --universal`
   - `python3 -m pip install --user --upgrade twine`
   - `python3 -m twine upload dist/*`
 - [ ] Test new version installs from PyPI

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,13 +17,13 @@
   ```
 - [ ] Test distribution
   ```bash
-  python3 -m pip install dist/becquerel-<version>-py2.py3-none-any.whl
-  python3 -m pip install dist/becquerel-<version>.tar.gz
+  python3 -m pip install dist/becquerel-X.X.X-py2.py3-none-any.whl
+  python3 -m pip install dist/becquerel-X.X.X.tar.gz
   ```
 - [ ] Upload new version to PyPI
   ```bash
   python3 -m pip install --user --upgrade twine
-  python3 -m twine upload dist/becquerel-<version>*
+  python3 -m twine upload dist/becquerel-X.X.X*
   ```
 - [ ] Test new version installs from PyPI
   ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,10 +8,14 @@
 - [ ] Update classifiers in `setup.py`
 - [ ] Verify that all tests pass (`python setup.py test`)
 - [ ] Commit the changes, push to GitHub, and start a pull request into `master`
-- [ ] After PR is accepted, create tagged version (`X.X.X`) on GitHub
+- [ ] Approve PR and merge it into master, but do not delete it yet
+- [ ] Create tagged version (`X.X.X`) on GitHub
 - [ ] Add release notes to the tag on GitHub with a list of changes
 - [ ] Create distribution
   ```bash
+  git pull
+  git checkout X.X.X
+  rm dist/*
   python3 -m pip install --user --upgrade setuptools wheel
   python3 setup.py sdist bdist_wheel --universal
   ```
@@ -23,7 +27,7 @@
 - [ ] Upload new version to PyPI
   ```bash
   python3 -m pip install --user --upgrade twine
-  python3 -m twine upload dist/becquerel-X.X.X*
+  python3 -m twine upload dist/*
   ```
 - [ ] Test new version installs from PyPI
   ```bash

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ NAME = 'becquerel'
 
 MAJOR = 0
 MINOR = 2
-MICRO = 0
+MICRO = 1
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, MICRO)
 
 DESCRIPTION = __doc__.split('\n')[0].split(': ')[-1]

--- a/setup.py
+++ b/setup.py
@@ -76,4 +76,5 @@ setup(
     install_requires=[_f for _f in REQUIREMENTS.split('\n') if _f],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-cov'],
+    license="Other/Proprietary License (see LICENSE.txt)",
 )


### PR DESCRIPTION
Closes #164, #165, #166

Hotfix for the following:
- Resolves issue with installing from PyPi in `python2`
- Adds `MANIFEST.in` for non-source text files
- Updates `RELEASING.md` for tagging, testing and uploading instructions
- Bumps MICRO version