### PR TITLE
Fix bug when empty line after $SPEC_REM tag in a spe file

### DIFF
--- a/becquerel/parsers/spe_file.py
+++ b/becquerel/parsers/spe_file.py
@@ -78,8 +78,7 @@ class SpeFile(SpectrumFile):
                 elif lines[i] == '$SPEC_REM:':
                     self.sample_description = ''
                     i += 1
-                    while i < len(lines) and ((len(lines[i]) == 0) or
-                                              (lines[i][0] != '$')):
+                    while i < len(lines) and not lines[i].startswith('$'):
                         self.sample_description += lines[i] + '\n'
                         i += 1
                     self.sample_description = self.sample_description[:-1]
@@ -117,7 +116,7 @@ class SpeFile(SpectrumFile):
                 elif lines[i] == '$ROI:':
                     self.ROIs = []
                     i += 1
-                    while i < len(lines) and lines[i][0] != '$':
+                    while i < len(lines) and not lines[i].startswith('$'):
                         self.ROIs.append(lines[i])
                         i += 1
                     i -= 1

--- a/becquerel/parsers/spe_file.py
+++ b/becquerel/parsers/spe_file.py
@@ -78,7 +78,8 @@ class SpeFile(SpectrumFile):
                 elif lines[i] == '$SPEC_REM:':
                     self.sample_description = ''
                     i += 1
-                    while i < len(lines) and lines[i][0] != '$':
+                    while i < len(lines) and ((len(lines[i]) == 0) or
+                                              (lines[i][0] != '$')):
                         self.sample_description += lines[i] + '\n'
                         i += 1
                     self.sample_description = self.sample_description[:-1]


### PR DESCRIPTION
A spe file with a blank line after the `$SPEC_REM` tag raises an `IndexError` when trying to get the first value of the line and checking that it isn't a `$`. I've fixed this in two places to use `startswith` instead.