### PR TITLE
Issue tests #200: Spectrum tests and associated changes to bin-related methods and docstrings

### DIFF
--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -949,6 +949,12 @@ class Spectrum(object):
                                     'uncalibrated Spectrum.')
 
         bin_widths = self.bin_widths_kev if use_kev else self.bin_widths_raw
+
+        # Iterate over the bin_widths, checking if each is the same within the
+        # relative tolerance rtol. Note: this is more or less equivalent to
+        #   np.allclose(bin_widths, bin_widths[0], rtol=rtol)
+        # except that the iterator approach terminates as soon as it finds the
+        # first non-uniform bin.
         iterator = iter(bin_widths)
         x0 = next(iterator, None)
         for x in iterator:

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -1003,6 +1003,9 @@ class Spectrum(object):
             bin edges, widths, centers
         """
 
+        if use_kev is None:
+            use_kev = self.is_calibrated
+
         if use_kev:
             if not self.is_calibrated:
                 raise SpectrumError('Cannot access energy bins with an ' +

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -956,16 +956,16 @@ class Spectrum(object):
         list of bin edges, then subtract 1 to get the index of the low edge.
 
         Args:
-            x: value(s) whose bin to find
-            use_kev: check bin_edges_kev if True, bin_edges_raw if False, or
-                decide based on self.is_calibrated if None
+          x: value(s) whose bin to find
+          use_kev: check bin_edges_kev if True, bin_edges_raw if False, or
+            decide based on self.is_calibrated if None
 
         Raises:
-            SpectrumError: if use_kev=True but Spectrum is not calibrated; or
-                if x is outside the bin edges or equal to up edge
+          SpectrumError: if use_kev=True but Spectrum is not calibrated; or if
+            x is outside the bin edges or equal to up edge
 
         Returns:
-            The integer bin index or indices containing x
+          The integer bin index or indices containing x
         """
 
         if use_kev is None:
@@ -992,13 +992,14 @@ class Spectrum(object):
         """Convenience function to get bin properties: edges, widths, centers.
 
         Args:
-            use_kev: if use_kev is False, use raw bins. If use_kev is True,
-                use kev bins, or raise SpectrumError if uncalibrated. If None,
-                decide based on self.is_calibrated
+          use_kev: if use_kev is False, use raw bins. If use_kev is True, use
+            kev bins, or raise SpectrumError if uncalibrated. If None, decide
+            based on self.is_calibrated
 
         Returns:
             bin edges, widths, centers
         """
+
         if use_kev:
             if not self.is_calibrated:
                 raise SpectrumError('Cannot access energy bins with an ' +

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -915,7 +915,7 @@ class Spectrum(object):
                             bin_edges_raw=self.bin_edges_raw,
                             livetime=new_livetime)
 
-    def has_uniform_bins(self, use_kev=True):
+    def has_uniform_bins(self, use_kev=None):
         """Test whether the Spectrum has uniform binning.
 
         This is possibly the best way to test for uniform binning within float
@@ -934,6 +934,9 @@ class Spectrum(object):
         Returns:
           True/False if all binwidths are equal to within np.finfo(float).eps
         """
+
+        if use_kev is None:
+            use_kev = self.is_calibrated
 
         if use_kev and not self.is_calibrated:
             raise SpectrumError('Cannot access energy bins with an ' +

--- a/examples/spectrum.ipynb
+++ b/examples/spectrum.ipynb
@@ -433,7 +433,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "becquerel/core/spectrum.py:726: SpectrumWarning: Subtraction of counts-based specta, spectra have been converted to CPS\n",
+      "becquerel/becquerel/core/spectrum.py:726: SpectrumWarning: Subtraction of counts-based specta, spectra have been converted to CPS\n",
       "  'have been converted to CPS', SpectrumWarning)\n"
      ]
     },
@@ -570,7 +570,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can create a Spectrum object from the data using default settings. We specify `use_kev=False` in `has_uniform_bins()` since the `Spectrum` has not yet been calibrated."
+    "We can create a Spectrum object from the data using default settings."
    ]
   },
   {
@@ -602,7 +602,7 @@
    "source": [
     "spec6 = Spectrum.from_listmode(lmd)\n",
     "print('nbins =', len(spec6))\n",
-    "print('Uniform bins?', spec6.has_uniform_bins(use_kev=False))\n",
+    "print('Uniform bins?', spec6.has_uniform_bins())\n",
     "plt.plot(spec6.counts_vals)\n",
     "plt.show()"
    ]
@@ -643,7 +643,7 @@
    "source": [
     "spec7 = Spectrum.from_listmode(lmd, bins=1000, xmin=0, xmax=10000)\n",
     "print('nbins =', len(spec7))\n",
-    "print('Uniform bins?', spec7.has_uniform_bins(use_kev=False))\n",
+    "print('Uniform bins?', spec7.has_uniform_bins())\n",
     "plt.plot(spec7.bin_edges_raw[:-1], spec7.counts_vals)\n",
     "plt.show()\n",
     "# Note that the Spectrum.plot() method fails here because it works in bin mode.\n",
@@ -707,7 +707,7 @@
     "logbins = np.logspace(3.6, 3.8, num=120)\n",
     "spec8 = Spectrum.from_listmode(lmd, bins=logbins)\n",
     "print('nbins =', len(spec8))\n",
-    "print('Uniform bins?', spec8.has_uniform_bins(use_kev=False))\n",
+    "print('Uniform bins?', spec8.has_uniform_bins())\n",
     "print(spec8.bin_widths_raw)\n",
     "plt.step(spec8.bin_centers_raw, spec8.counts_vals)\n",
     "plt.show()"
@@ -738,11 +738,11 @@
     }
    ],
    "source": [
-    "print(spec7.find_bin_index(3996, use_kev=False))\n",
-    "print(spec7.find_bin_index(0, use_kev=False))\n",
-    "print(spec7.find_bin_index(9999, use_kev=False))\n",
-    "print(spec7.find_bin_index(np.array([4000, 5000, 6000]), use_kev=False))\n",
-    "print(spec8.find_bin_index(np.array([4000, 5000, 6000]), use_kev=False))"
+    "print(spec7.find_bin_index(3996))\n",
+    "print(spec7.find_bin_index(0))\n",
+    "print(spec7.find_bin_index(9999))\n",
+    "print(spec7.find_bin_index(np.array([4000, 5000, 6000])))\n",
+    "print(spec8.find_bin_index(np.array([4000, 5000, 6000])))"
    ]
   },
   {
@@ -761,7 +761,7 @@
    "source": [
     "# test that the bin up edge is out-of-range\n",
     "try:\n",
-    "    print(spec7.find_bin_index(10000, use_kev=False))\n",
+    "    print(spec7.find_bin_index(10000))\n",
     "except SpectrumError:\n",
     "    print(\"Failed successfully!\")"
    ]
@@ -782,7 +782,7 @@
     }
    ],
    "source": [
-    "print(spec8.find_bin_index(3996, use_kev=False))\n",
+    "print(spec8.find_bin_index(3996))\n",
     "print(spec8.bin_edges_raw[0])\n",
     "print(spec8.bin_edges_raw[1])"
    ]

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -259,7 +259,7 @@ def make_spec_listmode(t, use_cal=False):
     return spec
 
 
-@pytest.mark.parametrize('use_cal', [False, True])
+@pytest.mark.parametrize('use_cal', [None, False, True])
 def test_listmode_uniform(use_cal):
     """Test listmode spectra with uniform binning.
 
@@ -285,7 +285,7 @@ def test_listmode_uniform(use_cal):
     assert spec.has_uniform_bins()
 
 
-@pytest.mark.parametrize('use_cal', [False, True])
+@pytest.mark.parametrize('use_cal', [None, False, True])
 def test_listmode_non_uniform(use_cal):
     """Test listmode spectra with non-uniform bins."""
     spec = make_spec_listmode('log', use_cal)
@@ -293,7 +293,7 @@ def test_listmode_non_uniform(use_cal):
     assert spec.has_uniform_bins() is False
 
 
-@pytest.mark.parametrize('use_cal', [False, True])
+@pytest.mark.parametrize('use_cal', [None, False, True])
 def test_listmode_no_args(use_cal):
     """Test listmode spectra without args."""
     spec = make_spec_listmode('default', use_cal)
@@ -301,7 +301,7 @@ def test_listmode_no_args(use_cal):
 
 
 @pytest.mark.parametrize('spec_str', ['uniform', 'log'])
-@pytest.mark.parametrize('use_cal', [False, True])
+@pytest.mark.parametrize('use_cal', [None, False, True])
 def test_find_bin_index(spec_str, use_cal):
     """Test that find_bin_index works for various spectrum objects."""
 
@@ -316,20 +316,14 @@ def test_find_bin_index(spec_str, use_cal):
     assert np.all(spec.find_bin_index(edges[:-1]) == np.arange(len(spec)))
 
 
-@pytest.mark.parametrize('spec', [
-    make_spec_listmode('uniform', use_cal=False),
-    make_spec_listmode('uniform', use_cal=True),
-    make_spec_listmode('default', use_cal=False),
-    make_spec_listmode('default', use_cal=True),
-    make_spec_listmode('log', use_cal=False),
-    make_spec_listmode('log', use_cal=True),
-    make_spec('uncal'),
-    make_spec('cal')])
-def test_index_out_of_bounds(spec):
+@pytest.mark.parametrize('spec_str', ['uniform', 'default', 'log'])
+@pytest.mark.parametrize('use_cal', [None, False, True])
+def test_index_out_of_bounds(spec_str, use_cal):
     """Raise a SpectrumError when we look for a bin index out of bounds, or an
     UncalibratedError when we ask to search bin_edges_kev in an uncal spectrum.
     """
 
+    spec = make_spec_listmode(spec_str, use_cal)
     edges, widths, _ = spec.get_bin_properties()
     xmin, xmax = edges[0], edges[-1]
 
@@ -345,9 +339,10 @@ def test_index_out_of_bounds(spec):
             spec.find_bin_index(xmin, use_kev=True)
 
 
-def test_bin_index_types():
+@pytest.mark.parametrize('use_cal', [None, False, True])
+def test_bin_index_types(use_cal):
     """Additional bin index type checking."""
-    spec = make_spec_listmode('uniform')
+    spec = make_spec_listmode('uniform', use_cal=use_cal)
     assert isinstance(spec.find_bin_index(XMIN), (int, np.integer))
     assert isinstance(spec.find_bin_index([XMIN]), np.ndarray)
 

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -296,13 +296,8 @@ def test_find_bin_index(spec):
         edges[:-1], use_kev=use_kev) == np.arange(len(spec)))
 
 
-# TODO further split these into making list mode, and testing indices
-# TODO also start a new issue that anywhere use_kev appears, it should be None
-#   by default, which then checks if spec.is_calibrated
-
-
 def test_listmode_no_args():
-    '''test without args'''
+    '''test listmode without args'''
     spec = make_spec_listmode('default')
     assert len(spec) == int(np.ceil(max(lmd)))
 

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -317,13 +317,17 @@ def test_find_bin_index(spec_str, use_cal):
 
 
 @pytest.mark.parametrize('spec', [
-    make_spec_listmode('uniform'),
-    make_spec_listmode('log'),
+    make_spec_listmode('uniform', use_cal=False),
+    make_spec_listmode('uniform', use_cal=True),
+    make_spec_listmode('default', use_cal=False),
+    make_spec_listmode('default', use_cal=True),
+    make_spec_listmode('log', use_cal=False),
+    make_spec_listmode('log', use_cal=True),
     make_spec('uncal'),
     make_spec('cal')])
 def test_index_out_of_bounds(spec):
-    """Raise a SpectrumError when we look for a bin index out of bounds, or
-    when we ask to search bin_edges_kev in an uncalibrated spectrum.
+    """Raise a SpectrumError when we look for a bin index out of bounds, or an
+    UncalibratedError when we ask to search bin_edges_kev in an uncal spectrum.
     """
 
     edges, widths, _ = spec.get_bin_properties()

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -269,7 +269,7 @@ def test_listmode_args(use_kev):
 
     # test with args
     assert len(spec) == NBINS
-    assert np.isclose(widths[0], BW)
+    assert np.all(np.isclose(widths, BW))
     assert edges[0] == XMIN
     assert edges[-1] == XMAX
     assert len(edges) == NBINS + 1
@@ -306,11 +306,10 @@ def test_find_bin_index(spec):
 
     edges, widths, _ = spec.get_bin_properties()
     xmin, xmax = edges[0], edges[-1]
-    bw = widths[0]
 
     assert spec.find_bin_index(xmin) == 0
-    assert spec.find_bin_index(xmin + bw/4.0) == 0
-    assert spec.find_bin_index(xmax - bw/4.0) == len(spec) - 1
+    assert spec.find_bin_index(xmin + widths[0]/4.0) == 0
+    assert spec.find_bin_index(xmax - widths[-1]/4.0) == len(spec) - 1
     assert np.all(spec.find_bin_index(edges[:-1]) == np.arange(len(spec)))
 
 
@@ -324,7 +323,6 @@ def test_index_out_of_bounds(spec):
 
     edges, widths, _ = spec.get_bin_properties()
     xmin, xmax = edges[0], edges[-1]
-    bw = widths[-1]
 
     # out of histogram bounds
     with pytest.raises(bq.SpectrumError):
@@ -333,7 +331,7 @@ def test_index_out_of_bounds(spec):
         print(i)
         print(len(spec))
     with pytest.raises(bq.SpectrumError):
-        spec.find_bin_index(xmin - bw/4.0)
+        spec.find_bin_index(xmin - widths[0]/4.0)
 
 
 # ----------------------------------------------

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -330,6 +330,7 @@ def test_index_out_of_bounds(spec):
         print(xmax)
         print(i)
         print(len(spec))
+        print(xmax >= edges[-1])
     with pytest.raises(bq.SpectrumError):
         spec.find_bin_index(xmin - widths[0]/4.0)
 

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -273,7 +273,7 @@ def test_listmode_args(use_kev):
     assert edges[0] == XMIN
     assert edges[-1] == XMAX
     assert len(edges) == NBINS + 1
-    assert spec.has_uniform_bins(use_kev=use_kev)
+    assert spec.has_uniform_bins()
 
 
 def test_listmode_no_args():
@@ -286,7 +286,7 @@ def test_listmode_non_uniform():
     """test non-uniform bins"""
     spec = make_spec_listmode('log')
     assert len(spec) == NBINS
-    assert spec.has_uniform_bins(use_kev=False) is False
+    assert spec.has_uniform_bins() is False
 
 
 def test_listmode_types():

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -309,19 +309,27 @@ def test_listmode_types():
         spec.find_bin_index([XMIN], use_kev=False), np.ndarray)
 
 
-@pytest.mark.parametrize('spec',
-                         [make_spec_listmode('uniform'), make_spec('uncal')])
+@pytest.mark.parametrize('spec', [
+    make_spec_listmode('uniform'),
+    make_spec_listmode('log'),
+    make_spec('uncal'),
+    make_spec('cal')])
 def test_index_out_of_bounds(spec):
     '''Raise a SpectrumError when we look for a bin index out of bounds.'''
 
+    if spec.is_calibrated:
+        edges, widths = spec.bin_edges_kev, spec.bin_widths_kev
+    else:
+        edges, widths = spec.bin_edges_raw, spec.bin_widths_raw
+
+    xmin, xmax = edges[0], edges[-1]
+    bw = widths[-1]
+
     # out of histogram bounds
-    xmin = spec.bin_edges_raw[0]
-    xmax = spec.bin_edges_raw[-1]
-    bw = spec.bin_widths_raw[-1]
     with pytest.raises(bq.SpectrumError):
-        spec.find_bin_index(xmax, use_kev=False)
+        spec.find_bin_index(xmax, use_kev=spec.is_calibrated)
     with pytest.raises(bq.SpectrumError):
-        spec.find_bin_index(xmin - bw/4.0, use_kev=False)
+        spec.find_bin_index(xmin - bw/4.0, use_kev=spec.is_calibrated)
 
 
 # ----------------------------------------------

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -313,9 +313,6 @@ def test_find_bin_index(spec_str, use_cal):
     assert spec.find_bin_index(xmin) == 0
     assert spec.find_bin_index(xmin + widths[0]/4.0) == 0
     assert spec.find_bin_index(xmax - widths[-1]/4.0) == len(spec) - 1
-    if spec_str == 'uniform' and use_cal:
-        print(spec.find_bin_index(edges[:-1]))
-        print(np.arange(len(spec)))
     assert np.all(spec.find_bin_index(edges[:-1]) == np.arange(len(spec)))
 
 


### PR DESCRIPTION
This splits up a large block of tests I had written previously into several smaller tests focusing separately on list mode and find index functionalities.