### PR TITLE
Update travis build spec, numba and llvmlite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
+dist: bionic
 language: python
 python:
     - "2.7"
     - "3.6"
+    - "3.7"
+    - "3.8"
 install:
     - pip install --upgrade pip setuptools wheel
     - pip install --only-binary=numpy,scipy numpy scipy
     - pip install -r requirements-dev.txt
     - python setup.py install
 script: "python setup.py test"
-# For now, only use Travis CI on master branch
 branches:
     only:
         - master

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ html5lib
 lxml
 matplotlib
 numba>=0.47.0
+llvmlite==0.31.0
 numpy
 pandas
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ future
 html5lib
 lxml
 matplotlib
-numba
+numba>=0.47.0
 numpy
 pandas
 python-dateutil


### PR DESCRIPTION
* Update travis to run on Ubuntu Bionic
* Update travis to use python 3.8
* Fix numba and lvmlite versions for python2. See https://github.com/numba/llvmlite/pull/580