### PR TITLE
Update requirements to deal with python2/3 llvmlite issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ html5lib
 lxml
 matplotlib
 numba>=0.47.0
-llvmlite==0.31.0
+llvmlite==0.31.0; python_version < "3"
+llvmlite; python_version >= "3"
 numpy
 pandas
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ lxml
 matplotlib
 numba>=0.47.0
 llvmlite==0.31.0; python_version < "3"
-llvmlite; python_version >= "3"
 numpy
 pandas
 python-dateutil


### PR DESCRIPTION
Fix the issue coming up in Travis with python3 versions:
```
error: llvmlite 0.31.0 is installed but llvmlite<0.34,>=0.33.0.dev0 is required by {'numba'}
```
