### PR TITLE
Adjust for recent changes to NNDC API

### DIFF
--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -700,7 +700,9 @@ A  	Element	Z  	N  	Energy  	JPi           	Mass Exc  	Unc  	T1/2 (txt)         
                 raise NNDCInputError(
                     'Decay mode must be one of {}, not {}'.format(
                         WALLET_DECAY_MODE.keys(), kwargs['decay'].lower()))
-            warnings.warn('query kwarg "decay" may not be working on NNDC')
+            warnings.warn('query kwarg "decay" may not be working on NNDC, ' +
+                          'and the user is advised to check the ' +
+                          '"Decay Mode" column of the resulting DataFrame')
             self._data['dmed'] = 'enabled'
             self._data['dmn'] = WALLET_DECAY_MODE[kwargs['decay'].lower()]
         # handle energy level condition

--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -700,6 +700,7 @@ A  	Element	Z  	N  	Energy  	JPi           	Mass Exc  	Unc  	T1/2 (txt)         
                 raise NNDCInputError(
                     'Decay mode must be one of {}, not {}'.format(
                         WALLET_DECAY_MODE.keys(), kwargs['decay'].lower()))
+            warnings.warn('query kwarg "decay" may not be working on NNDC')
             self._data['dmed'] = 'enabled'
             self._data['dmn'] = WALLET_DECAY_MODE[kwargs['decay'].lower()]
         # handle energy level condition

--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -433,6 +433,7 @@ class _NNDCQuery(object):
                 raise NNDCRequestError('Request failed: ' + resp.reason)
             for msg in [
                     'Your search was unsuccessful',
+                    'Your search exceeded the maximum number of results',
                     'There are too many results for your search',
             ]:
                 if msg in resp.text:

--- a/tests/nndc_test.py
+++ b/tests/nndc_test.py
@@ -637,6 +637,10 @@ class TestNuclearWalletCard(NNDCQueryTests):
             d = self.fetch(j='10')
             assert len(d) > 0
 
+    @pytest.mark.skip(reason='query kwarg "decay" seems to not be working' +
+                             'on NNDC, and as a result too many results' +
+                             'are returned for this test, causing an' +
+                             'NNDCRequestError')
     def test_wallet_decay_SF(self):
         """Test fetch_wallet_card: decay='SF'.............................."""
         kwargs = [kw for kw, val in nndc.WALLET_DECAY_MODE.items()

--- a/tests/nndc_test.py
+++ b/tests/nndc_test.py
@@ -637,9 +637,9 @@ class TestNuclearWalletCard(NNDCQueryTests):
             d = self.fetch(j='10')
             assert len(d) > 0
 
-    @pytest.mark.skip(reason='query kwarg "decay" seems to not be working' +
-                             'on NNDC, and as a result too many results' +
-                             'are returned for this test, causing an' +
+    @pytest.mark.skip(reason='query kwarg "decay" seems to not be working ' +
+                             'on NNDC, and as a result too many results ' +
+                             'are returned for this test, causing an ' +
                              'NNDCRequestError')
     def test_wallet_decay_SF(self):
         """Test fetch_wallet_card: decay='SF'.............................."""


### PR DESCRIPTION
It appears that two things have changed on NNDC in recent months:

(1) The error message that is returned when requesting too many wallet cards has changed
(2) The decay mode kwarg no longer seems to be honored in the query

Change (1) was leading to the recent test failures on Travis. Fixing (1) leads to (2) causing a separate test to fail, one that requests all wallet cards for spontaneous fission isotopes (`decay="SF"`), which used to be a small enough number to not matter but now thousands of isotopes are returned. This PR skips that test and raises a warning when specifying the `decay` kwarg.

Other tests whose queries are affected by (2) do not raise errors because they are generally not strict in their testing; they usually check that no error was raised by the query and that a nonzero number of elements was returned. We might want to consider making the NNDC testing more strict, but that could also make our code harder to maintain if their database changes.