### PR TITLE
From master to main transition

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-[MASTER]
+[MAIN]
 
 # Specify a configuration file.
 #rcfile=

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-[MAIN]
+[MASTER]
 
 # Specify a configuration file.
 #rcfile=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ install:
 script: "python setup.py test"
 branches:
     only:
-        - master
-        - develop
+        - main
 notifications:
   slack:
     secure: fbsAu4oLvRWKGpPLzJcjobftOK1bOjmvjkrJbQ2+QcrpWqhsU0oSrBr4812zOQBbtU3LkyAgOYOMeKtIqkxaUaZed+73Lv69ZpdBpzx0tY9Oj5Qm/sUYd8g2NjYnK3GpbSp3rK0CVMIhVAopM14GYqWTAoCLCeyDw5jNnx9gLW0AQN35dozKH0kEdp/q2kMt3vsd8/hauJjtiYsBzlIh4s+92qZiYgKkHzqvX27KUfwWNXve18QxYKlzldApVtmstm0J2o+tV8Wzx3x9FBSWJK40pXjVT/KEdWEdCLnh85ZtzEdRc7sRThDBKxQBuGkGm78a4pD5fj7imM7eVR9mQK9+nl1JJ/BOVwIz1ij7kF9Kl8WnGZkfU0W5eRwaJMXHv9ohP3yXXccloAjCHPS+Dr9nGeFNQKuGSTj2Pd9NDPhKh350hB1qA4cIu9uerrcHZEaSab0Ethc5xHPELZQXPmnthuPPlRSoCTaO9G2RKp07KdiTaC6UGUw9rkzaJEmTQU9Xzcpog3AdO/cBVQ7EMsWyPSQqn8vk9QO8Sj47h009IE4UzBbkfnDW2QYzv0LOgC8IvAdfuL6yo2ljATqFz9ppbPGnNEQA+FpBiuJKO/yI8k2NPLtKKQ5G9xPVriXwD0OMeMGLQk+yRrXmF3bOZ40b8eNpH/8AkwV1QgYsKBU=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,4 +62,4 @@ Use [google standards](https://google.github.io/styleguide/pyguide.html)
     - `pylint becquerel tests`
   - [ ] Spellcheck your code and docstrings
   - [ ] Check style is [consistent with Google Python style guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
-  - [ ] Push branch to GitHub and create a pull request to main
+  - [ ] Push branch to GitHub and create a pull request to `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Use [google standards](https://google.github.io/styleguide/pyguide.html)
 * Use `pylint` from command line (as in style guide)
 
 ### Checklist for code contributions:
-  - [ ] Branch off of `develop` and name the branch `feature-XX` or `issue-XX`
+  - [ ] Branch off of `main` and name the branch `feature-XX` or `issue-XX`
   - [ ] Develop the feature or fix
   - [ ] Write tests to cover all use cases
   - [ ] Ensure all tests pass (`python setup.py test`)
@@ -62,4 +62,4 @@ Use [google standards](https://google.github.io/styleguide/pyguide.html)
     - `pylint becquerel tests`
   - [ ] Spellcheck your code and docstrings
   - [ ] Check style is [consistent with Google Python style guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
-  - [ ] Push branch to GitHub and create a pull request
+  - [ ] Push branch to GitHub and create a pull request to main

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 We follow the `git flow` [release process](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
 
-- [ ] Pull the most recent versions of `main`
+- [ ] Pull the most recent version of `main`
 - [ ] Branch off of `main` and name the branch `release-X.X.X` or `hotfix-X`
 - [ ] Update version number within the repository
   - in `setup.py`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,8 +11,8 @@ We follow the `git flow` [release process](https://www.atlassian.com/git/tutoria
 - [ ] Update classifiers in `setup.py`
 - [ ] Verify that all tests pass (`python setup.py test`)
 - [ ] Commit the changes, push to GitHub, and start a pull request into `main`
-- [ ] Approve PR, merge it into main, and delete release or hotfix branch
-- [ ] Create tagged version (`X.X.X`) on GitHub pointing to the merge commit to main
+- [ ] Approve PR, merge it into `main`, and delete release or hotfix branch
+- [ ] Create tagged version (`X.X.X`) on GitHub pointing to the merge commit to `main`
 - [ ] Add release notes to the tag on GitHub with a list of changes
 
 ## 2. Distribution Creation/Upload

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,20 +2,17 @@
 
 We follow the `git flow` [release process](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
 
-- [ ] Pull the most recent versions of `develop` and `master`
-- If normal release:
-  - [ ] Branch off of `develop` and name the branch `release-X.X.X`
-- If hotfix/patch:
-  - [ ] Branch off of `master` and name the branch `hotfix-X`
+- [ ] Pull the most recent versions of `main`
+- [ ] Branch off of `main` and name the branch `release-X.X.X` or `hotfix-X`
 - [ ] Update version number within the repository
   - in `setup.py`
   - in Copyright Notice in `README`
   - in the `LICENSE`
 - [ ] Update classifiers in `setup.py`
 - [ ] Verify that all tests pass (`python setup.py test`)
-- [ ] Commit the changes, push to GitHub, and start a pull request into `master`
-- [ ] Approve PR and merge it into master, but do not delete it yet
-- [ ] Create tagged version (`X.X.X`) on GitHub
+- [ ] Commit the changes, push to GitHub, and start a pull request into `main`
+- [ ] Approve PR and merge it into main, and delete release or hotfix branch
+- [ ] Create tagged version (`X.X.X`) on GitHub pointing to the merge commit to main.
 - [ ] Add release notes to the tag on GitHub with a list of changes
 
 ## 2. Distribution Creation/Upload
@@ -44,8 +41,3 @@ We follow the `git flow` [release process](https://www.atlassian.com/git/tutoria
   python3 -m pip install becquerel
   python3 -c "import becquerel; print(becquerel.__version__)"
   ```
-
-## 3. Cleanup
-
-- [ ] Create PR from the `release-X.X.X`/`hotfix-X` branch into `develop`
-- [ ] After PR is accepted, delete the `release-X.X.X`/`hotfix-X` branch

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,8 +11,8 @@ We follow the `git flow` [release process](https://www.atlassian.com/git/tutoria
 - [ ] Update classifiers in `setup.py`
 - [ ] Verify that all tests pass (`python setup.py test`)
 - [ ] Commit the changes, push to GitHub, and start a pull request into `main`
-- [ ] Approve PR and merge it into main, and delete release or hotfix branch
-- [ ] Create tagged version (`X.X.X`) on GitHub pointing to the merge commit to main.
+- [ ] Approve PR, merge it into main, and delete release or hotfix branch
+- [ ] Create tagged version (`X.X.X`) on GitHub pointing to the merge commit to main
 - [ ] Add release notes to the tag on GitHub with a list of changes
 
 ## 2. Distribution Creation/Upload

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ We follow the `git flow` [release process](https://www.atlassian.com/git/tutoria
 - [ ] Verify that all tests pass (`python setup.py test`)
 - [ ] Commit the changes, push to GitHub, and start a pull request into `main`
 - [ ] Approve PR, merge it into `main`, and delete release or hotfix branch
-- [ ] Create tagged version (`X.X.X`) on GitHub pointing to the merge commit to `main`
+- [ ] Create tagged version (`X.X.X`) on [GitHub](https://github.com/lbl-anp/becquerel/releases/new) pointing to the merge commit to `main`
 - [ ] Add release notes to the tag on GitHub with a list of changes
 
 ## 2. Distribution Creation/Upload


### PR DESCRIPTION
This pull request will fix the internals so that we can rename master to main and remove develop.

Changes on github required to go along with this pull request:

- [x] Create a new branch `main` from head of `master` and push
- [x] Change default branch to `main`
- [x] Change this pull requests origin to `main`
- [x] Change all other pull request to `main`
- [ ] Merge pull request to `main`
- [ ] Remove `develop` and `master`

Let me know if I forgot something.