### PR TITLE
IsotopeQuantity retain floating point precision

### DIFF
--- a/becquerel/tools/isotope_qty.py
+++ b/becquerel/tools/isotope_qty.py
@@ -517,11 +517,12 @@ class IsotopeQuantity(object):
         if not isinstance(other, IsotopeQuantity):
             return False
         else:
-            # TODO: Do we need to compare all quantities?
+            # This supports uncertanties too
+            a = self._ref_quantities["atoms"]
+            b = other.atoms_at(self.ref_date)
             return (self.isotope == other.isotope and
-                    np.isclose(self._ref_quantities["atoms"],
-                               other.atoms_at(self.ref_date)))
-
+                    abs(a - b) <= 1e-9 * max(abs(a), abs(b))
+                   )
 
 class NeutronIrradiationError(Exception):
     """Exception from NeutronIrradiation class."""

--- a/becquerel/tools/isotope_qty.py
+++ b/becquerel/tools/isotope_qty.py
@@ -170,7 +170,7 @@ class IsotopeQuantity(object):
         # rotates the order of the list so that the provided kwarg is at [0]
         order = ["atoms", "bq", "uci", "g"]
         if next(iter(kwargs)) not in order:
-            raise IsotopeQuantityError("Unknow isotope quantity.")
+            raise IsotopeQuantityError("Unknown isotope quantity.")
         while order[0] not in kwargs:
             order.append(order.pop(0))
         first = order.pop(0)

--- a/becquerel/tools/isotope_qty.py
+++ b/becquerel/tools/isotope_qty.py
@@ -264,7 +264,7 @@ class IsotopeQuantity(object):
     # ----------------------------
 
     def quantity_at(self, quantity, date):
-        """Calculate the number of atoms at a given time.
+        """Return a quantity at a given time.
 
         Args:
           date: the date to calculate for

--- a/tests/isotope_qty_test.py
+++ b/tests/isotope_qty_test.py
@@ -107,7 +107,10 @@ def test_isotopequantity_ref_atoms_rad(radioisotope, iq_kwargs):
         assert iq.ref_atoms == iq_kwargs['bq'] / radioisotope.decay_const
     else:
         assert iq.ref_atoms == (
-            iq_kwargs['uci'] * UCI_TO_BQ / radioisotope.decay_const)
+            iq_kwargs['uci'] * UCI_TO_BQ / radioisotope.decay_const /
+            N_AV * radioisotope.A / radioisotope.A * N_AV)
+            # Note the last part cancels, but is necessary to get equality with
+            # floating points
 
 
 def test_isotopequantity_ref_atoms_stable(stable_isotope):
@@ -295,12 +298,12 @@ def test_isotopequantity_mul_div(iq, f):
     iq2 = iq * f
     assert iq2.isotope == iq.isotope
     assert iq2.ref_date == iq.ref_date
-    assert iq2.ref_atoms == iq.ref_atoms * f
+    assert iq2._ref_quantities["uci"] == iq._ref_quantities["uci"] * f
 
     iq3 = iq / f
     assert iq3.isotope == iq.isotope
     assert iq3.ref_date == iq.ref_date
-    assert iq3.ref_atoms == iq.ref_atoms / f
+    assert iq3._ref_quantities["uci"] == iq._ref_quantities["uci"] / f
 
 
 def test_isotopequantity_from_decays(iq):

--- a/tests/isotope_qty_test.py
+++ b/tests/isotope_qty_test.py
@@ -18,7 +18,7 @@ import pytest
 
 def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
     """function to work with uncertainties too."""
-    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
 # ----------------------------------------------------

--- a/tests/isotope_qty_test.py
+++ b/tests/isotope_qty_test.py
@@ -100,6 +100,14 @@ def test_isotopequantity_init_stable(stable_isotope, iq_date, iq_kwargs):
     assert iq.decay_const == stable_isotope.decay_const
 
 
+def test_isotopequantity_quantity_at(radioisotope, iq_kwargs):
+    """Test IsotopeQuantity.quantity_at for a radioactive isotope"""
+
+    iq = IsotopeQuantity(radioisotope, **iq_kwargs)
+    key = next(iter(iq_kwargs))
+    assert iq_kwargs[key] == iq.quantity_at(key, iq.ref_date)
+
+
 def test_isotopequantity_ref_atoms_rad(radioisotope, iq_kwargs):
     """Test IsotopeQuantity.ref_atoms for a radioactive isotope"""
 

--- a/tests/isotope_qty_test.py
+++ b/tests/isotope_qty_test.py
@@ -16,6 +16,11 @@ import becquerel as bq
 import pytest
 
 
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+    """function to work with uncertainties too."""
+    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
+
 # ----------------------------------------------------
 #               IsotopeQuantity class
 # ----------------------------------------------------
@@ -100,17 +105,16 @@ def test_isotopequantity_ref_atoms_rad(radioisotope, iq_kwargs):
 
     iq = IsotopeQuantity(radioisotope, **iq_kwargs)
     if 'atoms' in iq_kwargs:
-        assert iq.ref_atoms == iq_kwargs['atoms']
+        assert isclose(iq.ref_atoms, iq_kwargs['atoms'])
     elif 'g' in iq_kwargs:
-        assert iq.ref_atoms == (iq_kwargs['g'] / radioisotope.A * N_AV)
+        assert isclose(iq.ref_atoms, (iq_kwargs['g'] / radioisotope.A * N_AV))
     elif 'bq' in iq_kwargs:
-        assert iq.ref_atoms == iq_kwargs['bq'] / radioisotope.decay_const
+        assert isclose(iq.ref_atoms, iq_kwargs['bq'] / radioisotope.decay_const)
     else:
-        assert iq.ref_atoms == (
-            iq_kwargs['uci'] * UCI_TO_BQ / radioisotope.decay_const /
-            N_AV * radioisotope.A / radioisotope.A * N_AV)
-            # Note the last part cancels, but is necessary to get equality with
-            # floating points
+        assert isclose(
+            iq.ref_atoms,
+            iq_kwargs['uci'] * UCI_TO_BQ / radioisotope.decay_const
+        )
 
 
 def test_isotopequantity_ref_atoms_stable(stable_isotope):


### PR DESCRIPTION
Closes #222

These changes assure that whatever quantity is used to initalize a `IsotopeQuantity` that quantity will not be affected by floating point rounding errors.