### PR TITLE
Draft: store EnergyCal object in Spectrum

### DIFF
--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -139,6 +139,7 @@ class Spectrum(object):
         self._cps = None
         self._bin_edges_kev = None
         self._bin_edges_raw = None
+        self.cal = None
         self.livetime = None
         self.realtime = None
 
@@ -1033,6 +1034,7 @@ class Spectrum(object):
         """
 
         self.bin_edges_kev = cal.ch2kev(self.bin_edges_raw)
+        self.cal = cal
 
     def calibrate_like(self, other):
         """Apply another Spectrum object's calibration (bin edges vector).
@@ -1049,6 +1051,7 @@ class Spectrum(object):
 
         if other.is_calibrated:
             self.bin_edges_kev = other.bin_edges_kev.copy()
+            self.cal = other.cal
         else:
             raise UncalibratedError('Other spectrum is not calibrated')
 
@@ -1056,6 +1059,7 @@ class Spectrum(object):
         """Remove the calibration (if it exists) from this spectrum."""
 
         self.bin_edges_kev = None
+        self.cal = None
 
     def combine_bins(self, f):
         """Make a new Spectrum with counts combined into bigger bins.


### PR DESCRIPTION
I'm opening this since I think we talked about getting #180 soon as well. Is there anything other than simply adding a `self.cal` to `Spectrum`? Perhaps the `rebin` or `combine_bins` change the calibration, depending on how the calibration is defined?

Thoughts @jccurtis @markbandstra @cosama ?