### PR TITLE
Add a simple plot() method to Fitter

### DIFF
--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -729,6 +729,12 @@ class Fitter(object):
                 'Unknown residuals type: {0:s}'.format(residual_type)
             )
 
+    def plot(self):
+        """Plot the fit result on the current axis."""
+        x_plot = np.linspace(self.x_roi[0], self.x_roi[-1], 1000)
+        y = self.eval(x_plot, **self.result.best_values)
+        plt.plot(x_plot, y)
+
     def custom_plot(self, title=None, savefname=None, title_fontsize=24,
                     title_fontweight='bold', residual_type='abs', **kwargs):
         """Three-panel figure showing fit results.

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -729,11 +729,25 @@ class Fitter(object):
                 'Unknown residuals type: {0:s}'.format(residual_type)
             )
 
-    def plot(self):
-        """Plot the fit result on the current axis."""
-        x_plot = np.linspace(self.x_roi[0], self.x_roi[-1], 1000)
+    def plot(self, npts=1000, **kwargs):
+        """Plot the fit result on the current axis.
+
+        Parameters
+        ----------
+        npts : int (optional)
+            Number of points in x to generate.
+        kwargs : dict (optional)
+            Additional kwargs passed to plt.plot().
+
+        Returns
+        -------
+        int
+            Description of anonymous integer return value.
+        """
+
+        x_plot = np.linspace(self.x_roi[0], self.x_roi[-1], npts)
         y = self.eval(x_plot, **self.result.best_values)
-        plt.plot(x_plot, y)
+        plt.plot(x_plot, y, **kwargs)
 
     def custom_plot(self, title=None, savefname=None, title_fontsize=24,
                     title_fontweight='bold', residual_type='abs', **kwargs):

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -139,6 +139,7 @@ class Spectrum(object):
         self._cps = None
         self._bin_edges_kev = None
         self._bin_edges_raw = None
+        self.cal = None
         self.livetime = None
         self.realtime = None
 
@@ -1033,6 +1034,7 @@ class Spectrum(object):
         """
 
         self.bin_edges_kev = cal.ch2kev(self.bin_edges_raw)
+        self.cal = cal
 
     def calibrate_like(self, other):
         """Apply another Spectrum object's calibration (bin edges vector).
@@ -1049,6 +1051,7 @@ class Spectrum(object):
 
         if other.is_calibrated:
             self.bin_edges_kev = other.bin_edges_kev.copy()
+            self.cal = other.cal
         else:
             raise UncalibratedError('Other spectrum is not calibrated')
 
@@ -1056,6 +1059,7 @@ class Spectrum(object):
         """Remove the calibration (if it exists) from this spectrum."""
 
         self.bin_edges_kev = None
+        self.cal = None
 
     def combine_bins(self, f):
         """Make a new Spectrum with counts combined into bigger bins.

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -140,7 +140,6 @@ class Spectrum(object):
         self._cps = None
         self._bin_edges_kev = None
         self._bin_edges_raw = None
-        self.cal = None
         self.livetime = None
         self.realtime = None
 
@@ -1035,7 +1034,6 @@ class Spectrum(object):
         """
 
         self.bin_edges_kev = cal.ch2kev(self.bin_edges_raw)
-        self.cal = cal
 
     def calibrate_like(self, other):
         """Apply another Spectrum object's calibration (bin edges vector).
@@ -1052,7 +1050,6 @@ class Spectrum(object):
 
         if other.is_calibrated:
             self.bin_edges_kev = other.bin_edges_kev.copy()
-            self.cal = other.cal
         else:
             raise UncalibratedError('Other spectrum is not calibrated')
 
@@ -1060,7 +1057,6 @@ class Spectrum(object):
         """Remove the calibration (if it exists) from this spectrum."""
 
         self.bin_edges_kev = None
-        self.cal = None
 
     def combine_bins(self, f):
         """Make a new Spectrum with counts combined into bigger bins.


### PR DESCRIPTION
The `Fitter` class currently lacks a simple `plot` method for displaying just the fit result, especially if one wants to quickly overlay it on an existing plot. This provides such a method.