### PR TITLE
Store EnergyCal in Spectrum

### DIFF
--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -140,7 +140,7 @@ class Spectrum(object):
         self._cps = None
         self._bin_edges_kev = None
         self._bin_edges_raw = None
-        self.cal = None
+        self.energy_cal = None
         self.livetime = None
         self.realtime = None
 
@@ -1035,7 +1035,7 @@ class Spectrum(object):
         """
 
         self.bin_edges_kev = cal.ch2kev(self.bin_edges_raw)
-        self.cal = cal
+        self.energy_cal = cal
 
     def calibrate_like(self, other):
         """Apply another Spectrum object's calibration (bin edges vector).
@@ -1052,7 +1052,7 @@ class Spectrum(object):
 
         if other.is_calibrated:
             self.bin_edges_kev = other.bin_edges_kev.copy()
-            self.cal = other.cal
+            self.energy_cal = other.energy_cal
         else:
             raise UncalibratedError('Other spectrum is not calibrated')
 
@@ -1060,7 +1060,7 @@ class Spectrum(object):
         """Remove the calibration (if it exists) from this spectrum."""
 
         self.bin_edges_kev = None
-        self.cal = None
+        self.energy_cal = None
 
     def combine_bins(self, f):
         """Make a new Spectrum with counts combined into bigger bins.

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -140,6 +140,7 @@ class Spectrum(object):
         self._cps = None
         self._bin_edges_kev = None
         self._bin_edges_raw = None
+        self.cal = None
         self.livetime = None
         self.realtime = None
 
@@ -1034,6 +1035,7 @@ class Spectrum(object):
         """
 
         self.bin_edges_kev = cal.ch2kev(self.bin_edges_raw)
+        self.cal = cal
 
     def calibrate_like(self, other):
         """Apply another Spectrum object's calibration (bin edges vector).
@@ -1050,6 +1052,7 @@ class Spectrum(object):
 
         if other.is_calibrated:
             self.bin_edges_kev = other.bin_edges_kev.copy()
+            self.cal = other.cal
         else:
             raise UncalibratedError('Other spectrum is not calibrated')
 
@@ -1057,6 +1060,7 @@ class Spectrum(object):
         """Remove the calibration (if it exists) from this spectrum."""
 
         self.bin_edges_kev = None
+        self.cal = None
 
     def combine_bins(self, f):
         """Make a new Spectrum with counts combined into bigger bins.

--- a/tests/energycal_test.py
+++ b/tests/energycal_test.py
@@ -321,6 +321,7 @@ def test_apply_calibration(uncal_spec, chlist, kevlist):
     assert uncal_spec.is_calibrated
     assert np.allclose(
         uncal_spec.bin_edges_kev[:-1], cal.ch2kev(uncal_spec.channels))
+    assert uncal_spec.energy_cal is not None
 
 
 def test_apply_calibration_recal(cal_spec, chlist, kevlist):
@@ -330,6 +331,7 @@ def test_apply_calibration_recal(cal_spec, chlist, kevlist):
     old_bin_edges = cal_spec.bin_edges_kev
     cal_spec.apply_calibration(cal)
     assert not np.any(old_bin_edges == cal_spec.bin_edges_kev)
+    assert cal_spec.energy_cal is not None
 
 
 def test_rm_calibration(cal_spec):
@@ -338,6 +340,7 @@ def test_rm_calibration(cal_spec):
     assert cal_spec.is_calibrated
     cal_spec.rm_calibration()
     assert not cal_spec.is_calibrated
+    assert cal_spec.energy_cal is None
 
 
 def test_rm_calibration_error(uncal_spec):

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -164,6 +164,7 @@ def test_uncal(uncal_spec):
 
     assert len(uncal_spec.counts) == TEST_DATA_LENGTH
     assert not uncal_spec.is_calibrated
+    assert uncal_spec.energy_cal is None
 
 
 def test_uncal_cps(uncal_spec_cps):
@@ -171,6 +172,7 @@ def test_uncal_cps(uncal_spec_cps):
 
     assert len(uncal_spec_cps.cps) == TEST_DATA_LENGTH
     assert not uncal_spec_cps.is_calibrated
+    assert uncal_spec_cps.energy_cal is None
 
 
 def test_cal(cal_spec):

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -258,6 +258,7 @@ def make_spec_listmode(t, use_cal=False):
     if use_cal:
         cal = bq.LinearEnergyCal.from_coeffs({'m': TEST_GAIN, 'b': 0.0})
         spec.apply_calibration(cal)
+        assert spec.energy_cal is not None
     return spec
 
 


### PR DESCRIPTION
Fix the auto merge of #229 

> I'm opening this since I think we talked about getting #180 soon as well. Is there anything other than simply adding a self.cal to Spectrum? Perhaps the rebin or combine_bins change the calibration, depending on how the calibration is defined?
> 
> Thoughts @jccurtis @markbandstra @cosama ?