### PR TITLE
plot the fit evaluation error bands, and ensure fit is shown above other lines

### DIFF
--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -814,7 +814,17 @@ class Fitter(object):
         # Best fit
         y = self.eval(x_plot, **self.result.best_values)
         ymin, ymax = min(y.min(), ymin), max(y.max(), ymax)
-        fit_ax.plot(x_plot, y, color='#e31a1c', label='best fit')
+        fit_ax.plot(x_plot, y, color='#e31a1c', label='best fit', zorder=10)
+        yunc = self.result.eval_uncertainty(x=x_plot, sigma=1)
+        fit_ax.fill_between(
+            x_plot,
+            y-yunc,
+            y+yunc,
+            label=r'$\pm 1\, \sigma$',
+            color='#e31a1c',
+            alpha=0.2,
+            zorder=9
+        )
         # Components (currently will work for <=3 component)
         colors = ['#1f78b4', '#33a02c', '#6a3d9a']
         for i, m in enumerate(self.result.model.components):

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -815,16 +815,17 @@ class Fitter(object):
         y = self.eval(x_plot, **self.result.best_values)
         ymin, ymax = min(y.min(), ymin), max(y.max(), ymax)
         fit_ax.plot(x_plot, y, color='#e31a1c', label='best fit', zorder=10)
-        yunc = self.result.eval_uncertainty(x=x_plot, sigma=1)
-        fit_ax.fill_between(
-            x_plot,
-            y-yunc,
-            y+yunc,
-            label=r'$\pm 1\, \sigma$',
-            color='#e31a1c',
-            alpha=0.2,
-            zorder=9
-        )
+        if self.result.success:
+            yunc = self.result.eval_uncertainty(x=x_plot, sigma=1)
+            fit_ax.fill_between(
+                x_plot,
+                y-yunc,
+                y+yunc,
+                label=r'$\pm 1\, \sigma$',
+                color='#e31a1c',
+                alpha=0.2,
+                zorder=9
+            )
         # Components (currently will work for <=3 component)
         colors = ['#1f78b4', '#33a02c', '#6a3d9a']
         for i, m in enumerate(self.result.model.components):


### PR DESCRIPTION
Quick PR to add error bounds from the fit to `custom_plot`, and also ensure that the fit line and error band are drawn above other lines

![image](https://user-images.githubusercontent.com/7683814/109368775-15e4d580-784f-11eb-9457-6151408b9497.png)
