### PR TITLE
Support for Spectrum HDF5 I/O

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Becquerel-specific files
+tests/test_io
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/becquerel/io/__init__.py
+++ b/becquerel/io/__init__.py
@@ -1,0 +1,5 @@
+"""HDF5 I/O tools."""
+
+from . import h5
+
+__all__ = ["h5"]

--- a/becquerel/io/h5.py
+++ b/becquerel/io/h5.py
@@ -1,0 +1,120 @@
+"""Simple tools to perform HDF5 I/O."""
+
+import pathlib
+from typing import Union, Tuple
+import h5py
+
+
+def is_h5_filename(name: str):
+    """Return True if the lowercase filename ends with h5 or hdf5.
+
+    Parameters
+    ----------
+    name : str
+        The filename to examine.
+
+    Returns
+    -------
+    is_h5 : bool
+    """
+    try:
+        ext = pathlib.Path(name).suffix
+        return ext.lower().endswith((".h5", ".hdf5"))
+    except TypeError:
+        return False
+
+
+class open_h5(object):
+    """Context manager to allow I/O given HDF5 filename, File, or Group."""
+
+    def __init__(self, name: Union[str, h5py.File, h5py.Group], mode=None, **kwargs):
+        """Initialize the context manager.
+
+        Parameters
+        ----------
+        name : str, h5py.File, h5py.Group
+            The filename or an open h5py File or Group.
+        mode : str
+            The I/O mode. Default is None.
+        kwargs : dict
+            Additional keyword arguments sent to h5py.File if initializing.
+        """
+        self._already_h5_obj = isinstance(name, (h5py.File, h5py.Group))
+        if not self._already_h5_obj:
+            assert is_h5_filename(name), "Filename must end in h5 or hdf5"
+        self.name = name
+        self.mode = mode
+        self.kwargs = kwargs
+        self.file = None
+
+    def __enter__(self):
+        """Open the file for I/O.
+
+        Returns
+        -------
+        file : h5py.File, h5py.Group
+            An open h5py File or Group.
+        """
+        if self._already_h5_obj:
+            self.file = self.name
+        else:
+            self.file = h5py.File(self.name, mode=self.mode, **self.kwargs)
+        return self.file
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Close the file if it had to open it in __enter__."""
+        if not self._already_h5_obj:
+            self.file.close()
+
+
+def write_h5(name: Union[str, h5py.File, h5py.Group], dsets: dict, attrs: dict) -> None:
+    """Write the datasets and attributes to an HDF5 file or group.
+
+    Parameters
+    ----------
+    name : str, h5py.File, h5py.Group
+        The filename or an open h5py File or Group.
+    dsets : dict
+        Dictionary of data to be written as datasets.
+    attrs : dict
+        Dictionary of data to be written as attributes.
+    """
+    with open_h5(name, "w") as file:
+        # write the datasets
+        for key in dsets.keys():
+            file.create_dataset(key, data=dsets[key])
+        # write the attributes
+        file.attrs.update(attrs)
+
+
+def read_h5(name: Union[str, h5py.File, h5py.Group]) -> Tuple[dict, dict, list]:
+    """Read the datasets and attributes from an HDF5 file or group.
+
+    Parameters
+    ----------
+    name : str, h5py.File, h5py.Group
+        The filename or an open h5py File or Group.
+
+    Returns
+    -------
+    dsets : dict
+        Dictionary of data to be written as datasets.
+    attrs : dict
+        Dictionary of data to be written as attributes.
+    skipped : list
+        List of keys of skipped items.
+    """
+    dsets = {}
+    attrs = {}
+    skipped = []
+    with open_h5(name, "r") as file:
+        # read the datasets
+        for key in file.keys():
+            # skip any non-datasets
+            if not isinstance(file[key], h5py.Dataset):
+                skipped.append(str(key))
+            else:
+                dsets[key] = file[key][()]
+        # read the attributes
+        attrs = dict(file.attrs)
+    return dsets, attrs, skipped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4
 future
+h5py
 html5lib
 lmfit
 lxml

--- a/tests/h5_tools_test.py
+++ b/tests/h5_tools_test.py
@@ -1,0 +1,209 @@
+"""Test HDF5 I/O tools."""
+
+import os
+import h5py
+import numpy as np
+import pytest
+from becquerel.io.h5 import is_h5_filename, open_h5, write_h5, read_h5
+
+
+TEST_IO = os.path.join(os.path.split(__file__)[0], "test_io")
+if not os.path.exists(TEST_IO):
+    os.mkdir(TEST_IO)
+
+DSETS = {
+    "dset_1d": np.ones(100, dtype=int),
+    "dset_2d": np.ones((30, 30), dtype=float),
+    "dset_0d": 7,
+    "dset_str": "test",
+}
+
+ATTRS = {
+    "str": "testing",
+    "float": 1.3,
+    "list": [1, 2, 3],
+    "ndarray": np.ones(10),
+}
+
+
+def test_is_h5_filename():
+    """Test functionality of is_h5_filename."""
+    assert is_h5_filename("test.h5")
+    assert is_h5_filename("test.hdf5")
+    assert is_h5_filename("test.H5")
+    assert is_h5_filename("test.HDF5")
+    assert not is_h5_filename("test.csv")
+    assert not is_h5_filename("test.spe")
+    assert not is_h5_filename(None)
+
+
+def write_test_open_h5_file(fname):
+    """Write the test file for test_open_h5."""
+    with h5py.File(fname, "w") as file:
+        file.create_dataset("test_dset", data=[1, 2, 3])
+        group = file.create_group("test_group")
+        group.create_dataset("group_dset", data=[1, 2, 3])
+
+
+def test_open_h5():
+    """Test open_h5 for different inputs."""
+    fname = os.path.join(TEST_IO, "__test_open_h5.h5")
+
+    # filename cases
+    write_test_open_h5_file(fname)
+    with open_h5(fname, "r") as f:
+        print(list(f.keys()))
+
+    write_test_open_h5_file(fname)
+    with open_h5(fname, "w") as f:
+        print(list(f.keys()))
+        f.create_dataset("test_dset_1", data=[1, 2, 3])
+
+    write_test_open_h5_file(fname)
+    with open_h5(fname, "r+") as f:
+        print(list(f.keys()))
+        f.create_dataset("test_dset_2", data=[1, 2, 3])
+
+    # h5py.File cases
+    write_test_open_h5_file(fname)
+    with h5py.File(fname, "r") as file:
+        print(list(file.keys()))
+        with open_h5(file) as f:
+            print(list(f.keys()))
+            with pytest.raises(ValueError):
+                f.create_dataset("test_dset_3", data=[1, 2, 3])
+
+    write_test_open_h5_file(fname)
+    with h5py.File(fname, "r+") as file:
+        print(list(file.keys()))
+        with open_h5(file) as f:
+            print(list(f.keys()))
+            f.create_dataset("test_dset_4", data=[1, 2, 3])
+
+    write_test_open_h5_file(fname)
+    with h5py.File(fname, "w") as file:
+        print(list(file.keys()))
+        with open_h5(file) as f:
+            print(list(f.keys()))
+            f.create_dataset("test_dset_5", data=[1, 2, 3])
+
+    # h5py.Group cases
+    write_test_open_h5_file(fname)
+    with h5py.File(fname, "r") as file:
+        print(list(file.keys()))
+        group = file["test_group"]
+        with open_h5(group) as f:
+            print(list(f.keys()))
+            with pytest.raises(ValueError):
+                f.create_dataset("group_dset_1", data=[1, 2, 3])
+
+    write_test_open_h5_file(fname)
+    with h5py.File(fname, "r+") as file:
+        print(list(file.keys()))
+        group = file["test_group"]
+        with open_h5(group) as f:
+            print(list(f.keys()))
+            f.create_dataset("group_dset_2", data=[1, 2, 3])
+
+    write_test_open_h5_file(fname)
+    with h5py.File(fname, "w") as file:
+        print(list(file.keys()))
+        group = file.create_group("test_group")
+        with open_h5(group) as f:
+            print(list(f.keys()))
+            f.create_dataset("group_dset_3", data=[1, 2, 3])
+
+
+def check_dsets_attrs(dsets1, attrs1, dsets2, attrs2):
+    """Check that the dataset and attribute dicts are identical."""
+    assert set(dsets1.keys()) == set(dsets2.keys())
+    assert set(attrs1.keys()) == set(attrs2.keys())
+    for key in dsets1.keys():
+        if "str" in key:
+            assert dsets1[key] == dsets2[key]
+        else:
+            assert np.allclose(dsets1[key], dsets2[key])
+    for key in attrs1.keys():
+        if "str" in key:
+            assert attrs1[key] == attrs2[key]
+        else:
+            assert np.allclose(attrs1[key], attrs2[key])
+
+
+@pytest.mark.parametrize("dsets", [DSETS])
+@pytest.mark.parametrize("attrs", [ATTRS])
+def test_write_h5_filename(dsets, attrs):
+    """Write data to h5 given its filename."""
+    fname = os.path.join(TEST_IO, "__test_write_h5_filename.h5")
+    write_h5(fname, dsets, attrs)
+
+
+@pytest.mark.parametrize("dsets", [DSETS])
+@pytest.mark.parametrize("attrs", [ATTRS])
+def test_write_h5_file(dsets, attrs):
+    """Write data to h5 given an open h5py.File."""
+    fname = os.path.join(TEST_IO, "__test_write_h5_file.h5")
+    with h5py.File(fname, "w") as file:
+        write_h5(file, dsets, attrs)
+
+
+@pytest.mark.parametrize("dsets", [DSETS])
+@pytest.mark.parametrize("attrs", [ATTRS])
+def test_write_h5_group(dsets, attrs):
+    """Write data to h5 given an h5py.Group."""
+    fname = os.path.join(TEST_IO, "__test_write_h5_group.h5")
+    with h5py.File(fname, "w") as file:
+        group = file.create_group("test_group")
+        write_h5(group, dsets, attrs)
+
+
+@pytest.mark.parametrize("dsets", [DSETS])
+@pytest.mark.parametrize("attrs", [ATTRS])
+def test_read_h5_filename(dsets, attrs):
+    """Read data from h5 given its filename."""
+    fname = os.path.join(TEST_IO, "__test_write_h5_filename.h5")
+    dsets2, attrs2, skipped = read_h5(fname)
+    check_dsets_attrs(dsets, attrs, dsets2, attrs2)
+    assert len(skipped) == 0
+
+
+@pytest.mark.parametrize("dsets", [DSETS])
+@pytest.mark.parametrize("attrs", [ATTRS])
+def test_read_h5_file(dsets, attrs):
+    """Read data from h5 given an open h5py.File."""
+    fname = os.path.join(TEST_IO, "__test_write_h5_file.h5")
+    with h5py.File(fname, "r") as file:
+        dsets2, attrs2, skipped = read_h5(file)
+    check_dsets_attrs(dsets, attrs, dsets2, attrs2)
+    assert len(skipped) == 0
+
+
+@pytest.mark.parametrize("dsets", [DSETS])
+@pytest.mark.parametrize("attrs", [ATTRS])
+def test_read_h5_group(dsets, attrs):
+    """Read data from h5 given an h5py.Group."""
+    fname = os.path.join(TEST_IO, "__test_write_h5_group.h5")
+    with h5py.File(fname, "r") as file:
+        group = file["test_group"]
+        dsets2, attrs2, skipped = read_h5(group)
+    check_dsets_attrs(dsets, attrs, dsets2, attrs2)
+    assert len(skipped) == 0
+
+
+@pytest.mark.parametrize("dsets", [DSETS])
+@pytest.mark.parametrize("attrs", [ATTRS])
+def test_read_h5_ignore_group(dsets, attrs):
+    """Read data from h5 and ignore a data group within the group."""
+    fname = os.path.join(TEST_IO, "__test_write_h5_ignore_group.h5")
+
+    # write the file with an extra group
+    with h5py.File(fname, "w") as file:
+        file.create_group("test_group")
+        write_h5(file, dsets, attrs)
+
+    # read the file, ignoring the group
+    with h5py.File(fname, "r") as file:
+        print("file:", file)
+        dsets2, attrs2, skipped = read_h5(file)
+    check_dsets_attrs(dsets, attrs, dsets2, attrs2)
+    assert skipped == ["test_group"]

--- a/tests/spectrum_io_test.py
+++ b/tests/spectrum_io_test.py
@@ -1,0 +1,69 @@
+"""Test Spectrum I/O for different file types."""
+
+import os
+import pytest
+import becquerel as bq
+from h5_tools_test import TEST_IO
+from spectrum_test import make_spec
+from parsers_test import SAMPLES
+
+
+@pytest.mark.parametrize("extension", SAMPLES.keys())
+def test_spectrum_from_file(extension):
+    """Test Spectrum.from_file for the given extension."""
+    filenames = SAMPLES[extension]
+    assert len(filenames) >= 1
+    for filename in filenames:
+        spec = bq.Spectrum.from_file(filename)
+        assert spec.livetime is not None
+
+
+def test_spectrum_from_file_raises():
+    """Test Spectrum.from_file raises error for an unsupported file type."""
+    with pytest.raises(NotImplementedError):
+        bq.Spectrum.from_file("foo.bar")
+
+
+@pytest.mark.parametrize(
+    "kind", ["uncal", "cal", "cal_new", "cal_cps", "uncal_long", "uncal_cps"]
+)
+def test_write_h5(kind):
+    """Test writing different Spectrums to HDF5 files."""
+    spec = make_spec(kind, lt=600.0)
+    fname = os.path.join(TEST_IO, "__test_spectrum_io_" + kind + ".h5")
+    spec.write_h5(fname)
+
+
+@pytest.mark.parametrize(
+    "kind", ["uncal", "cal", "cal_new", "cal_cps", "uncal_long", "uncal_cps"]
+)
+def test_read_h5(kind):
+    """Test reading different Spectrums from HDF5 files."""
+    fname = os.path.join(TEST_IO, "__test_spectrum_io_" + kind + ".h5")
+    spec = bq.Spectrum.read_h5(fname)
+    assert spec.livetime is not None
+
+
+@pytest.mark.parametrize(
+    "kind", ["uncal", "cal", "cal_new", "cal_cps", "uncal_long", "uncal_cps"]
+)
+def test_file_file_h5(kind):
+    """Test Spectrum.from_file works for HDF5 files."""
+    fname = os.path.join(TEST_IO, "__test_spectrum_io_" + kind + ".h5")
+    spec = bq.Spectrum.from_file(fname)
+    assert spec.livetime is not None
+
+
+@pytest.mark.parametrize("extension", SAMPLES.keys())
+def test_spectrum_samples_write_read_h5(extension):
+    """Test Spectrum HDF5 I/O using sample files."""
+    filenames = SAMPLES[extension]
+    assert len(filenames) >= 1
+    for filename in filenames:
+        spec = bq.Spectrum.from_file(filename)
+        fname2 = os.path.splitext(filename)[0] + ".h5"
+        fname2 = os.path.join(TEST_IO, os.path.split(fname2)[1])
+        spec.write_h5(fname2)
+        spec = bq.Spectrum.read_h5(fname2)
+        spec = bq.Spectrum.from_file(fname2)
+        assert spec.livetime is not None

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -5,7 +5,7 @@ import datetime
 import numpy as np
 from uncertainties import ufloat, UFloat, unumpy
 import becquerel as bq
-from parsers_test import SAMPLES
+
 
 TEST_DATA_LENGTH = 256
 TEST_COUNTS = 4
@@ -110,51 +110,6 @@ def cal_spec_2(spec_data):
     """Generate a calibrated spectrum (2nd instance)."""
 
     return make_spec("cal")
-
-
-# -----------------------------------------------------------------------------
-# File IO
-# -----------------------------------------------------------------------------
-
-
-@pytest.fixture
-def cal_spec_cps(spec_data):
-    """Generate a calibrated spectrum with cps data."""
-
-    return bq.Spectrum(cps=spec_data, bin_edges_kev=TEST_EDGES_KEV)
-
-
-class TestSpectrumFromFile(object):
-    """Test Spectrum.from_file() class method."""
-
-    def run_from_file(self, extension):
-        """Run the test of from_file() for files with the given extension."""
-        filenames = SAMPLES.get(extension, [])
-        assert len(filenames) >= 1
-        for filename in filenames:
-            spec = bq.Spectrum.from_file(filename)
-            assert spec.livetime is not None
-
-    def test_spe(self):
-        """Test Spectrum.from_file for SPE file........................."""
-        with pytest.warns(bq.parsers.SpectrumFileParsingWarning):
-            self.run_from_file(".spe")
-
-    def test_spc(self):
-        """Test Spectrum.from_file for SPC file........................."""
-
-        self.run_from_file(".spc")
-
-    def test_cnf(self):
-        """Test Spectrum.from_file for CNF file........................."""
-
-        self.run_from_file(".cnf")
-
-    def test_error(self):
-        """Test _get_file_object() raises error for bad file type"""
-
-        with pytest.raises(NotImplementedError):
-            bq.Spectrum.from_file("foo.bar")
 
 
 # ----------------------------------------------


### PR DESCRIPTION
Adds the ability to read and write `Spectrum`s to the [HDF5 file format](https://www.hdfgroup.org/solutions/hdf5/) using [h5py](https://www.h5py.org). Resolves a long outstanding issue of wanting to support writing spectra to file in some custom format (#44).

Addresses issues raised in #87, #179, #181.

- [x] Add basic tools for HDF5 I/O
- [x] Add HDF5 I/O to Spectrum
- [ ] Store extra information from the parsers, currently discarded, in a `Spectrum.attrs` dictionary and include those as attributes in the HDF5.
- [ ] add `EnergyCal` HDF5 I/O (or defer to refactor of calibrations)
- [ ] read and write the `Spectrum`'s energy calibration to HDF5 if it is not `None`
- [ ] clean up inheritance structure of `Spectrum` parsers and enforce DRY (#19 and #103)
- [ ] parse SPE ROI block (#181)