### PR TITLE
Use COVERALLS_REPO_TOKEN

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -27,6 +27,7 @@ jobs:
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop
       with:
+        github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
         parallel: true
         flag-name: Unit Test
 
@@ -37,5 +38,6 @@ jobs:
     - name: Coveralls Finished
       uses: AndreMiras/coveralls-python-action@develop
       with:
+        github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
         parallel-finished: true
         debug: true


### PR DESCRIPTION
Following coveralls documentation I have found some issues getting out coverage to update. I have included the COVERALLS_REPO_TOKEN as a secret and am testing if this fixes the issue. I've also purged becquerel from coveralls for a fresh start to see if `main` is picked up as the default branch.

See: https://coveralls.io/github/lbl-anp/becquerel