### PR TITLE
np.float and np.int are deprecated

### DIFF
--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -429,7 +429,7 @@ class Fitter(object):
     @y_unc.setter
     def y_unc(self, y_unc):
         if y_unc is not None:
-            self._y_unc = np.asarray(y_unc, dtype=np.float)
+            self._y_unc = np.asarray(y_unc, dtype=float)
             assert len(self.x) == len(
                 self._y_unc
             ), "Fitting x (len {}) does not match y_unc (len {})".format(
@@ -806,7 +806,7 @@ class Fitter(object):
             diff[mask] = 1e32
             if diff.dtype == np.complex:
                 # data/model are complex
-                diff = diff.ravel().view(np.float)
+                diff = diff.ravel().view(float)
             return np.asarray(diff).ravel()  # for compatibility with pandas.Series
 
         # This overwrites the  model residual method, is an ugly hack to make
@@ -888,7 +888,7 @@ class Fitter(object):
         """
         if self.result is None:
             return None
-        df = pd.DataFrame(columns=["val", "unc"], dtype=np.float)
+        df = pd.DataFrame(columns=["val", "unc"], dtype=float)
         for k in self.param_names:
             df.loc[k, "val"] = self.param_val(k)
             df.loc[k, "unc"] = self.param_unc(k)

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -629,7 +629,7 @@ class Spectrum(object):
         if xmax is None:
             xmax = np.ceil(max(listmode_data))
         if bins is None:
-            bins = np.arange(xmin, xmax + 1, dtype=np.int)
+            bins = np.arange(xmin, xmax + 1, dtype=int)
 
         assert xmin < xmax
         if isinstance(bins, int):

--- a/becquerel/parsers/cnf_file.py
+++ b/becquerel/parsers/cnf_file.py
@@ -115,8 +115,8 @@ class CnfFile(SpectrumFile):
         print("CnfFile: Reading file " + self.filename)
         self.realtime = 0.0
         self.livetime = 0.0
-        self.channels = np.array([], dtype=np.float)
-        self.data = np.array([], dtype=np.float)
+        self.channels = np.array([], dtype=float)
+        self.data = np.array([], dtype=float)
         self.cal_coeff = []
         data = []
         with open(self.filename, "rb") as f:

--- a/becquerel/parsers/spc_file.py
+++ b/becquerel/parsers/spc_file.py
@@ -224,8 +224,8 @@ class SpcFile(SpectrumFile):
         print("SpcFile: Reading file " + self.filename)
         self.realtime = 0.0
         self.livetime = 0.0
-        self.channels = np.array([], dtype=np.float)
-        self.data = np.array([], dtype=np.float)
+        self.channels = np.array([], dtype=float)
+        self.data = np.array([], dtype=float)
         self.cal_coeff = []
         with open(self.filename, "rb") as f:
             # read the file in chunks of 128 bytes

--- a/becquerel/parsers/spe_file.py
+++ b/becquerel/parsers/spe_file.py
@@ -65,8 +65,8 @@ class SpeFile(SpectrumFile):
         print("SpeFile: Reading file " + self.filename)
         self.realtime = 0.0
         self.livetime = 0.0
-        self.channels = np.array([], dtype=np.float)
-        self.data = np.array([], dtype=np.float)
+        self.channels = np.array([], dtype=float)
+        self.data = np.array([], dtype=float)
         self.cal_coeff = []
         with open(self.filename, "r") as f:
             # read & remove newlines from end of each line

--- a/becquerel/parsers/spectrum_file.py
+++ b/becquerel/parsers/spectrum_file.py
@@ -54,11 +54,11 @@ class SpectrumFile(object):
         # miscellaneous metadata
         self.metadata = {}
         # arrays to be read from file
-        self.channels = np.array([], dtype=np.float)
-        self.data = np.array([], dtype=np.float)
+        self.channels = np.array([], dtype=float)
+        self.data = np.array([], dtype=float)
         self.cal_coeff = []
         # arrays to be calculated using calibration
-        self.energies = np.array([], dtype=np.float)
+        self.energies = np.array([], dtype=float)
         self.bin_edges_kev = None
 
     def __str__(self):

--- a/tests/energycal_test.py
+++ b/tests/energycal_test.py
@@ -50,7 +50,7 @@ def spec_data():
     """Build a vector of random counts."""
 
     floatdata = np.random.poisson(lam=TEST_COUNTS, size=TEST_DATA_LENGTH)
-    return floatdata.astype(np.int)
+    return floatdata.astype(int)
 
 
 @pytest.fixture

--- a/tests/fitting_test.py
+++ b/tests/fitting_test.py
@@ -28,7 +28,7 @@ def get_model_name(x):
 
 def sim_data(x_min, x_max, y_func, num_x=200, binning="linear", **params):
     if binning == "linear":
-        edges = np.linspace(x_min, x_max, num_x, dtype=np.float)
+        edges = np.linspace(x_min, x_max, num_x, dtype=float)
     elif binning == "sqrt":
         edges = np.linspace(np.sqrt(x_min), np.sqrt(x_max), num_x)
         edges = edges ** 2
@@ -37,7 +37,7 @@ def sim_data(x_min, x_max, y_func, num_x=200, binning="linear", **params):
 
     y_smooth = y_func(x=x, **params) * dx
     np.random.seed(1)
-    y = np.random.poisson(y_smooth).astype(np.float)
+    y = np.random.poisson(y_smooth).astype(float)
     y_unc = np.sqrt(y)
     return {"x": x, "y": y, "y_unc": y_unc, "dx": dx}
 

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -21,7 +21,7 @@ def spec_data():
     """Build a vector of random counts."""
 
     floatdata = np.random.poisson(lam=TEST_COUNTS, size=TEST_DATA_LENGTH)
-    return floatdata.astype(np.int)
+    return floatdata.astype(int)
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def cal_spec_cps(spec_data):
 @pytest.fixture(params=[1, 10, 100])
 def y_counts_spec(request):
     floatdata = np.random.poisson(lam=request.param, size=TEST_DATA_LENGTH)
-    return bq.Spectrum(floatdata.astype(np.int))
+    return bq.Spectrum(floatdata.astype(int))
 
 
 # @pytest.fixture

--- a/tests/rebin_test.py
+++ b/tests/rebin_test.py
@@ -24,7 +24,7 @@ import becquerel as bq
     ],
 )
 def old_edges(request):
-    return request.param.astype(np.float)
+    return request.param.astype(float)
 
 
 @pytest.fixture(
@@ -42,7 +42,7 @@ def old_edges(request):
     ],
 )
 def new_edges(request):
-    return request.param.astype(np.float)
+    return request.param.astype(float)
 
 
 @pytest.fixture(params=[1, 5, 25], ids=["sparse counts", "~5 counts", "~25 counts"])
@@ -65,7 +65,7 @@ def old_spec_int(lam, old_edges):
     return old_edges, counts
 
 
-def make_fake_spec_array(lam, size, dtype=np.float):
+def make_fake_spec_array(lam, size, dtype=float):
     return np.random.poisson(lam=lam, size=size).astype(dtype)
 
 

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -17,7 +17,7 @@ def make_data(lam=TEST_COUNTS, size=TEST_DATA_LENGTH):
     """Build a vector of random counts."""
 
     floatdata = np.random.poisson(lam=lam, size=size)
-    return floatdata.astype(np.int)
+    return floatdata.astype(int)
 
 
 def make_spec(t, lt=None, lam=TEST_COUNTS):
@@ -1083,7 +1083,7 @@ def test_copy_cal(cal_spec):
     ids=["same edges", "subset of edges", "same bounds more bins"],
 )
 def rebin_new_edges(request):
-    return request.param.astype(np.float)
+    return request.param.astype(float)
 
 
 @pytest.fixture(


### PR DESCRIPTION
Closes #272.

This fixes those to to `float` and `int`.