### PR TITLE
2021 copyright and bump2version

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,13 +1,15 @@
-Becquerel v. 0.3.0, Copyright (c) 2017, The Regents of the University of
-California (UC), through Lawrence Berkeley National Laboratory, and the UC
-Berkeley campus (subject to receipt of any required approvals from the U.S.
-Dept. of Energy). All rights reserved. If you have questions about your rights
-to use or distribute this software, please contact Berkeley Lab's Innovation &
-Partnerships Office at  IPO@lbl.gov.
+becquerel (bq) Copyright (c) 2017-2021, The Regents of the University of
+California, through Lawrence Berkeley National Laboratory (subject to receipt
+of any required approvals from the U.S. Dept. of Energy) and University of
+California, Berkeley.  All rights reserved.
 
-NOTICE. This Software was developed under funding from the U.S. Department of
-Energy and the U.S. Government consequently retains certain rights. As such,
-the U.S. Government has been granted for itself and others acting on its
-behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
-to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so.
+If you have questions about your rights to use or distribute this software,
+please contact Berkeley Lab's Intellectual Property Office at
+IPO@lbl.gov.
+
+NOTICE.  This Software was developed under funding from the U.S. Department
+of Energy and the U.S. Government consequently retains certain rights.  As
+such, the U.S. Government has been granted for itself and others acting on
+its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+Software to reproduce, distribute copies to the public, prepare derivative
+works, and perform publicly and display publicly, and to permit others to do so.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,29 +1,45 @@
-*** Copyright Notice ***
-
-Becquerel v. 0.3.0, Copyright (c) 2017, The Regents of the University of
-California (UC), through Lawrence Berkeley National Laboratory, and the UC
-Berkeley campus (subject to receipt of any required approvals from the U.S.
-Dept. of Energy). All rights reserved. If you have questions about your rights
-to use or distribute this software, please contact Berkeley Lab's Innovation &
-Partnerships Office at  IPO@lbl.gov.
-
-NOTICE. This Software was developed under funding from the U.S. Department of
-Energy and the U.S. Government consequently retains certain rights. As such,
-the U.S. Government has been granted for itself and others acting on its
-behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
-to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so.
-
 *** License Agreement ***
 
- Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+becquerel (bq) Copyright (c) 2017-2021, The Regents of the University of
+California, through Lawrence Berkeley National Laboratory (subject to receipt
+of any required approvals from the U.S. Dept. of Energy) and University of
+California, Berkeley.  All rights reserved.
 
- (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
- (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+(1) Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
 
- (3) Neither the name of the University of California, University of California, Berkeley, Lawrence Berkeley National Laboratory, or the U.S. Dept. of Energy nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+(2) Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+(3) Neither the name of the University of California, Lawrence Berkeley
+National Laboratory, U.S. Dept. of Energy, University of California,
+Berkeley nor the names of its contributors may be used to endorse or
+promote products derived from this software without specific prior written
+permission.
 
-You are under no obligation whatsoever to provide any bug fixes, patches, or upgrades to the features, functionality or performance of the source code ("Enhancements") to anyone; however, if you choose to make your Enhancements available either publicly, or directly to Lawrence Berkeley National Laboratory, without imposing a separate written license agreement for such Enhancements, then you hereby grant the following license to Lawrence Berkeley National Laboratory, University if California, Berkeley, and the U.S. Dept. of Energy: a  non-exclusive, royalty-free perpetual license to install, use, modify, prepare derivative works, incorporate into other computer software, distribute, and sublicense such enhancements or derivative works thereof, in binary and source code form.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+You are under no obligation whatsoever to provide any bug fixes, patches,
+or upgrades to the features, functionality or performance of the source
+code ("Enhancements") to anyone; however, if you choose to make your
+Enhancements available either publicly, or directly to Lawrence Berkeley
+National Laboratory, without imposing a separate written license agreement
+for such Enhancements, then you hereby grant the following license: a
+non-exclusive, royalty-free perpetual license to install, use, modify,
+prepare derivative works, incorporate into other computer software,
+distribute, and sublicense such enhancements or derivative works thereof,
+in binary and source code form.

--- a/README.md
+++ b/README.md
@@ -56,16 +56,18 @@ code formatting and are converting to [`numpydoc`][4].
 
 ## Copyright Notice
 
-Becquerel v. 0.3.0, Copyright (c) 2017, The Regents of the University of
-California (UC), through Lawrence Berkeley National Laboratory, and the UC
-Berkeley campus (subject to receipt of any required approvals from the U.S.
-Dept. of Energy). All rights reserved. If you have questions about your rights
-to use or distribute this software, please contact Berkeley Lab's Innovation &
-Partnerships Office at  IPO@lbl.gov.
+becquerel (bq) Copyright (c) 2017-2021, The Regents of the University of
+California, through Lawrence Berkeley National Laboratory (subject to receipt
+of any required approvals from the U.S. Dept. of Energy) and University of
+California, Berkeley.  All rights reserved.
 
-NOTICE. This Software was developed under funding from the U.S. Department of
-Energy and the U.S. Government consequently retains certain rights. As such,
-the U.S. Government has been granted for itself and others acting on its
-behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
-to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so.
+If you have questions about your rights to use or distribute this software,
+please contact Berkeley Lab's Intellectual Property Office at
+IPO@lbl.gov.
+
+NOTICE.  This Software was developed under funding from the U.S. Department
+of Energy and the U.S. Government consequently retains certain rights.  As
+such, the U.S. Government has been granted for itself and others acting on
+its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+Software to reproduce, distribute copies to the public, prepare derivative
+works, and perform publicly and display publicly, and to permit others to do so.

--- a/becquerel/__metadata__.py
+++ b/becquerel/__metadata__.py
@@ -6,7 +6,7 @@ __maintainer__ = __author__
 __email__ = "becquerel-dev@lbl.gov"
 __description__ = "Tools for radiation spectral analysis."
 __url__ = "https://github.com/lbl-anp/becquerel"
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 # classifiers from list at https://pypi.org/classifiers/
 __classifiers__ = [
     "Development Status :: 4 - Beta",

--- a/becquerel/__metadata__.py
+++ b/becquerel/__metadata__.py
@@ -24,17 +24,19 @@ __classifiers__ = [
 ]
 __license__ = "Other/Proprietary License (see LICENSE.txt)"
 __copyright__ = """\
-Becquerel v. 0.3.0, Copyright (c) 2017, The Regents of the University of
-California (UC), through Lawrence Berkeley National Laboratory, and the UC
-Berkeley campus (subject to receipt of any required approvals from the U.S.
-Dept. of Energy). All rights reserved. If you have questions about your rights
-to use or distribute this software, please contact Berkeley Lab's Innovation &
-Partnerships Office at  IPO@lbl.gov.
+becquerel (bq) Copyright (c) 2017-2021, The Regents of the University of
+California, through Lawrence Berkeley National Laboratory (subject to receipt
+of any required approvals from the U.S. Dept. of Energy) and University of
+California, Berkeley.  All rights reserved.
 
-NOTICE. This Software was developed under funding from the U.S. Department of
-Energy and the U.S. Government consequently retains certain rights. As such,
-the U.S. Government has been granted for itself and others acting on its
-behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
-to reproduce, distribute copies to the public, prepare derivative works, and
-perform publicly and display publicly, and to permit other to do so.
+If you have questions about your rights to use or distribute this software,
+please contact Berkeley Lab's Intellectual Property Office at
+IPO@lbl.gov.
+
+NOTICE.  This Software was developed under funding from the U.S. Department
+of Energy and the U.S. Government consequently retains certain rights.  As
+such, the U.S. Government has been granted for itself and others acting on
+its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+Software to reproduce, distribute copies to the public, prepare derivative
+works, and perform publicly and display publicly, and to permit others to do so.
 """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ black==21.4b2
 pytest>=3.0.0
 pytest-cov
 pytest-black
+bump2version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 asteval
 beautifulsoup4
-black>=20.8b1
 future
 h5py
 html5lib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,21 @@
+[bumpversion]
+current_version = 0.4.0
+commit = True
+tag = False
+
 [aliases]
 test = pytest
 
 [tool:pytest]
 addopts = --black --cov=becquerel --cov-report term --cov-report html:htmlcov -m "not plottest"
-markers =
-    webtest: test requires internet connection
-    plottest: test will produce plot figures
-filterwarnings =
-    always
-    ; Not fixing the problem: https://github.com/pytest-dev/pytest/pull/3613
-    ignore:.*t resolve package from __spec__ or __package__.*:ImportWarning
+markers = 
+	webtest: test requires internet connection
+	plottest: test will produce plot figures
+filterwarnings = 
+	always
+	ignore:.*t resolve package from __spec__ or __package__.*:ImportWarning
 
 [coverage:run]
 relative_files = True
-
-[bumpversion]
-current_version = 0.3.0
-commit = True
-tag = False
 
 [bumpversion:file:becquerel/__metadata__.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,10 @@ filterwarnings =
 
 [coverage:run]
 relative_files = True
+
+[bumpversion]
+current_version = 0.3.0
+commit = True
+tag = False
+
+[bumpversion:file:becquerel/__metadata__.py]

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -5,42 +5,14 @@ import becquerel as bq
 COPYRIGHT = (REPO_PATH / "COPYRIGHT.txt").read_text()
 LICENSE = (REPO_PATH / "LICENSE.txt").read_text()
 README = (REPO_PATH / "README.md").read_text()
-COPYRIGHT_IN_LICENSE = (
-    LICENSE.split("*** Copyright Notice ***")[-1]
-    .split("*** License Agreement ***")[0]
-    .strip()
-    + "\n"
-)
 
 
 class TestCopyright:
     def test_license(self):
-        assert COPYRIGHT == COPYRIGHT_IN_LICENSE
+        assert COPYRIGHT == LICENSE.split("\n\n")[1]
 
     def test_readme(self):
         assert README.endswith(COPYRIGHT)
 
     def test_metadata(self):
         assert bq.__metadata__.__copyright__ == COPYRIGHT
-
-
-class TestVersion:
-    def test_copyright(self):
-        assert (
-            COPYRIGHT.split("Becquerel v. ")[1].split(",")[0]
-            == bq.__metadata__.__version__
-        )
-
-    def test_license(self):
-        assert (
-            LICENSE.split("Becquerel v. ")[1].split(",")[0]
-            == bq.__metadata__.__version__
-        )
-
-    def test_readme(self):
-        assert (
-            README.split("## Copyright Notice")[1]
-            .split("Becquerel v. ")[1]
-            .split(",")[0]
-            == bq.__metadata__.__version__
-        )

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -9,7 +9,8 @@ README = (REPO_PATH / "README.md").read_text()
 
 class TestCopyright:
     def test_license(self):
-        assert COPYRIGHT == LICENSE.split("\n\n")[1]
+        # The license only contains the first paragraph from the copyright
+        assert COPYRIGHT.split("\n\n")[0] == LICENSE.split("\n\n")[1]
 
     def test_readme(self):
         assert README.endswith(COPYRIGHT)


### PR DESCRIPTION
* Updates copyright and license text
* Removes version number test since this is no longer in the copyright
* Adds `bump2version`
* Bumps version -> `0.4.0`
* Linked to LBNL OSS - 2021-164