### PR TITLE
Bump version: 0.4.0 → 0.4.1

### DIFF
--- a/becquerel/__metadata__.py
+++ b/becquerel/__metadata__.py
@@ -6,7 +6,7 @@ __maintainer__ = __author__
 __email__ = "becquerel-dev@lbl.gov"
 __description__ = "Tools for radiation spectral analysis."
 __url__ = "https://github.com/lbl-anp/becquerel"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 # classifiers from list at https://pypi.org/classifiers/
 __classifiers__ = [
     "Development Status :: 4 - Beta",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = False
 


### PR DESCRIPTION
This PR will testing the auto deploy to pypi action. Once we merge this in we can tag `main`