### PR TITLE
Version v0.4.3 with pypi CD improvements and bump2version/pre-commit fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.4.3
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.4.2
+commit = True
+tag = False
+
+[bumpversion:file:becquerel/__metadata__.py]

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -8,6 +8,7 @@ name: pypi
 # Run on push/PR/manually BUT only uploads with a tag (see below)
 on:
   push:
+    branches: [ $default-branch ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -5,9 +5,10 @@
 
 name: pypi
 
+# Run on push/PR/manually BUT only uploads with a tag (see below)
 on:
   push:
-    tags: [ 'v*' ]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -29,4 +30,9 @@ jobs:
         uses: casperdcl/deploy-pypi@v2
         with:
           password: ${{ secrets.PYPI_TOKEN }}
-          pip: wheel -w dist/ --no-deps .
+          # Create source tgz
+          build: true
+          # Create wheel
+          pip: true
+          # Only upload if a tag is pushed (otherwise just build & check)
+          upload: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}

--- a/becquerel/__metadata__.py
+++ b/becquerel/__metadata__.py
@@ -6,7 +6,7 @@ __maintainer__ = __author__
 __email__ = "becquerel-dev@lbl.gov"
 __description__ = "Tools for radiation spectral analysis."
 __url__ = "https://github.com/lbl-anp/becquerel"
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 # classifiers from list at https://pypi.org/classifiers/
 __classifiers__ = [
     "Development Status :: 4 - Beta",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 0.4.2
-commit = True
-tag = False
-
 [aliases]
 test = pytest
 
@@ -17,5 +12,3 @@ filterwarnings =
 
 [coverage:run]
 relative_files = True
-
-[bumpversion:file:becquerel/__metadata__.py]


### PR DESCRIPTION
* Update pypi workflow to always run (build/check), only upload with a new tag and include the source+wheel
* Move `bump2version` config to its own file to avoid issues with `pre-commit`
* Rolls patch version