### PR TITLE
Downgrade fitting error

### DIFF
--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -887,12 +887,16 @@ class Fitter:
         grad = nd.Gradient(_calc_area)
         g = np.atleast_2d(grad(values, xvals=xvals, model=model, names=names)).T
 
+        # Compute the gradient with respect to the best fit parameters
+        grad = nd.Gradient(_calc_area)
+        g = np.atleast_2d(grad(values, xvals=xvals, model=model, names=names)).T
+
         # Compute the variance in the area estimate: Tellinghuisen Eq. 1
         if "minuit" in self.backend:
-            covariance = np.array(self.result.covariance)
+            covariance = self.result.covariance
         else:
-            covariance = np.array(self.result.covar)
-        if not covariance.sum():
+            covariance = self.result.covar
+        if covariance is None:
             warnings.warn(
                 "The covariance could not be estimated. Returning 0 for error estimate",
                 FittingWarning,

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -896,7 +896,7 @@ class Fitter:
             covariance = self.result.covariance
         else:
             covariance = self.result.covar
-        if covariance is None:
+        if covariance is None or np.allclose(covariance, 0.0):
             warnings.warn(
                 "The covariance could not be estimated. Returning 0 for error estimate",
                 FittingWarning,

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -898,6 +898,8 @@ class Fitter:
                 FittingWarning,
             )
             covariance = np.zeros((len(g), len(g)))
+        else:
+            covariance = self.covariance
         area_variance = g.T @ covariance @ g
         area_variance = area_variance[0, 0]
         # We don't divide by the binwidth here because we are summing bins: if we double
@@ -974,7 +976,7 @@ class Fitter:
     def covariance(self):
         """Wrapper for fit covariance matrix."""
         if "lmfit" in self.backend:
-            return self.result.cov
+            return self.result.covar
         elif "minuit" in self.backend:
             return self.result.covariance
         else:

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -846,7 +846,8 @@ class Fitter:
         if "lmfit" in self.backend:
             warnings.warn(
                 "`lmfit` error estimates are unreliable. "
-                "`minuit` is recommended where possible"
+                "`minuit` is recommended where possible",
+                FittingWarning,
             )
 
         def _calc_area(param_vec, **kwargs):

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -892,11 +892,7 @@ class Fitter:
         g = np.atleast_2d(grad(values, xvals=xvals, model=model, names=names)).T
 
         # Compute the variance in the area estimate: Tellinghuisen Eq. 1
-        if "minuit" in self.backend:
-            covariance = self.result.covariance
-        else:
-            covariance = self.result.covar
-        if covariance is None or np.allclose(covariance, 0.0):
+        if self.covariance is None or np.allclose(self.covariance, 0.0):
             warnings.warn(
                 "The covariance could not be estimated. Returning 0 for error estimate",
                 FittingWarning,
@@ -971,6 +967,16 @@ class Fitter:
             return self.result.success
         elif "minuit" in self.backend:
             return self.result.valid
+        else:
+            raise FittingError("Unknown backend: {}", self.backend)
+
+    @property
+    def covariance(self):
+        """Wrapper for fit covariance matrix."""
+        if "lmfit" in self.backend:
+            return self.result.cov
+        elif "minuit" in self.backend:
+            return self.result.covariance
         else:
             raise FittingError("Unknown backend: {}", self.backend)
 

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -892,7 +892,11 @@ class Fitter:
         else:
             covariance = np.array(self.result.covar)
         if not covariance.sum():
-            raise FittingError("No covariance!")
+            warnings.warn(
+                "The covariance could not be estimated. Returning 0 for error estimate",
+                FittingWarning,
+            )
+            covariance = np.zeros((len(g), len(g)))
         area_variance = g.T @ covariance @ g
         area_variance = area_variance[0, 0]
         # We don't divide by the binwidth here because we are summing bins: if we double

--- a/tests/fitting_test.py
+++ b/tests/fitting_test.py
@@ -329,13 +329,9 @@ class TestFittingHighStatSimData:
                 fitter.calc_area_and_unc()
             return
 
-        # Sometimes the fit result does not have a reliable covariance matrix, but alas
-        if "minuit" in fitter.backend:
-            covariance = fitter.result.covariance
-        else:
-            covariance = fitter.result.covar
+        # Sometimes the fit result does not have a reliable covariance matrix, but alas.
         # We can at least check that it properly warns, then skip the rest of the tests
-        if covariance is None:
+        if fitter.covariance is None:
             with pytest.warns(bq.fitting.FittingWarning):
                 a = fitter.calc_area_and_unc()
                 assert a.std_dev == 0
@@ -345,11 +341,7 @@ class TestFittingHighStatSimData:
         # fit quality, so let's synthetically create a zero covariance case and test it
         fitter_copy = deepcopy(fitter)
         fitter_copy.fit(sim_high_stat["method"])
-        if "minuit" in fitter.backend:
-            covariance = fitter_copy.result.covariance
-        else:
-            covariance = fitter_copy.result.covar
-        if covariance is not None:
+        if fitter.covariance is not None:
             if "minuit" in fitter.backend:
                 fitter_copy.result._covariance *= 0
             else:

--- a/tests/fitting_test.py
+++ b/tests/fitting_test.py
@@ -334,10 +334,11 @@ class TestFittingHighStatSimData:
             covariance = np.array(fitter.result.covariance)
         else:
             covariance = np.array(fitter.result.covar)
-        # We can at least check that it properly errors, then skip the rest of the tests
+        # We can at least check that it properly warns, then skip the rest of the tests
         if not covariance.sum():
-            with pytest.raises(bq.fitting.FittingError):
-                fitter.calc_area_and_unc()
+            with pytest.warns(bq.fitting.FittingWarning):
+                a = fitter.calc_area_and_unc()
+                assert a.std_dev == 0
             return
 
         # Area under the entire curve

--- a/tests/fitting_test.py
+++ b/tests/fitting_test.py
@@ -342,7 +342,7 @@ class TestFittingHighStatSimData:
         fitter_copy = deepcopy(fitter)
         fitter_copy.fit(sim_high_stat["method"])
         if fitter_copy.covariance is not None:
-            if "minuit" in fitter.backend:
+            if "minuit" in fitter_copy.backend:
                 fitter_copy.result._covariance *= 0
             else:
                 fitter_copy.result.covar *= 0

--- a/tests/fitting_test.py
+++ b/tests/fitting_test.py
@@ -341,7 +341,7 @@ class TestFittingHighStatSimData:
         # fit quality, so let's synthetically create a zero covariance case and test it
         fitter_copy = deepcopy(fitter)
         fitter_copy.fit(sim_high_stat["method"])
-        if fitter.covariance is not None:
+        if fitter_copy.covariance is not None:
             if "minuit" in fitter.backend:
                 fitter_copy.result._covariance *= 0
             else:


### PR DESCRIPTION
Return 0 error estimate and warn instead of crashing in `Fitter.calc_area_and_unc()`