### PR TITLE
Remove notebook calls to IsotopeQuantity.*_now methods and update docs

### DIFF
--- a/becquerel/tools/isotope_qty.py
+++ b/becquerel/tools/isotope_qty.py
@@ -64,16 +64,18 @@ class IsotopeQuantity:
       ref_atoms: the number of atoms of the isotope, at the reference time.
 
     Methods:
-      atoms_at: number of atoms at given time
-      bq_at: activity in Bq at given time
-      uci_at: activity in uCi at given time
-      g_at: mass in grams at given time
-      atoms_now, bq_now, uci_now, g_now: quantity at current time
+      atoms_at: number of atoms at given time, defaults to system time
+      bq_at: activity in Bq at given time, defaults to system time
+      uci_at: activity in uCi at given time, defaults to system time
+      g_at: mass in grams at given time, defaults to system time
       decays_from: number of decays during a time interval
       bq_from, uci_from: average activity during a time interval
       decays_during: number of decays during a Spectrum measurement
       bq_during, uci_during: average activity during a Spectrum measurement
       time_when: time at which activity or mass equals a given value
+
+    Deprecated:
+      atoms_now, bq_now, uci_now, g_now: quantity at current time (use *_at(None))
     """
 
     def __init__(self, isotope, date=None, stability=1e18, **kwargs):

--- a/examples/isotopes.ipynb
+++ b/examples/isotopes.ipynb
@@ -212,7 +212,7 @@
    ],
    "source": [
     "cs137_chk = IsotopeQuantity(cs137, date='2008-01-15', uci=11.13)\n",
-    "cs137_chk.uci_now()"
+    "cs137_chk.uci_at()"
    ]
   },
   {
@@ -249,7 +249,7 @@
     "na22_chk = IsotopeQuantity('na22', date='2008-01-15', uci=10.21)\n",
     "\n",
     "for chk in (ba133_chk, cd109_chk, co57_chk, co60_chk, mn54_chk, na22_chk):\n",
-    "    print('{}: {:.3f} uCi'.format(chk.isotope, chk.uci_now()))"
+    "    print('{}: {:.3f} uCi'.format(chk.isotope, chk.uci_at()))"
    ]
   },
   {
@@ -326,7 +326,7 @@
     }
    ],
    "source": [
-    "cd109_chk.bq_now()"
+    "cd109_chk.bq_at()"
    ]
   },
   {
@@ -366,7 +366,7 @@
     }
    ],
    "source": [
-    "co57_chk.atoms_now()"
+    "co57_chk.atoms_at()"
    ]
   },
   {

--- a/examples/overview.ipynb
+++ b/examples/overview.ipynb
@@ -1100,7 +1100,7 @@
    ],
    "source": [
     "ba133_chk = bq.IsotopeQuantity('ba133', date='2013-05-01', uci=10.02)\n",
-    "ba133_chk.uci_now()"
+    "ba133_chk.uci_at()"
    ]
   },
   {


### PR DESCRIPTION
This is a quick one in response to #325