### PR TITLE
Include or exclude "overflow" events when rebinning

### DIFF
--- a/becquerel/core/rebin.py
+++ b/becquerel/core/rebin.py
@@ -164,7 +164,7 @@ def _rebin_interpolation(
       in_spectrum: iterable of input spectrum counts in each bin
       in_edges: iterable of input bin edges (len = len(in_spectrum) + 1)
       out_edges_no_rightmost: iterable of output bin edges
-                              (sans the rightmost bin)
+                              (sans the rightmost bin edge)
       slopes: the slopes of each histogram bin, with the lines drawn between
               each bin edge. (len = len(in_spectrum))
       out_spectrum: for nb.guvectorize; This is the return array, do not
@@ -278,6 +278,7 @@ def rebin(
     method="interpolation",
     slopes=None,
     zero_pad_warnings=True,
+    include_overflows=False,
 ):
     """
     Spectra rebinning via deterministic or stochastic methods.
@@ -307,6 +308,9 @@ def rebin(
             [num_spectra, num_bins_in + 1] or [num_bins_in + 1]
         zero_pad_warnings (boolean): warn when edge overlap results in
             appending empty bins
+        include_overflows (boolean): whether to include counts below
+            out_edges[0] and above out_edges[-1] in the first and last
+            of the "out" bins, respectively, or to discard them (default).
 
     Raises:
         AssertionError: for bad input arguments
@@ -362,12 +366,35 @@ def rebin(
     _check_any_overlap(in_edges, out_edges)
     if zero_pad_warnings:
         _check_partial_overlap(in_edges, out_edges)
+
+    # add an extra bin at each end if we don't want overflow counts in
+    # the first and last bins
+    if not include_overflows:
+        if not np.isfinite(out_edges[0]):
+            raise RebinError(
+                "Lowest output edge must be finite if not including overflows"
+            )
+        if not np.isfinite(out_edges[-1]):
+            raise RebinError(
+                "Highest output edge must be finite if not including overflows"
+            )
+        out_edges_temp = np.concatenate(
+            (np.array([-np.inf]), out_edges, np.array([np.inf]))
+        )
+    else:
+        out_edges_temp = out_edges
+
     # Remove highest output edge, necessary for guvectorize
-    out_edges = out_edges[..., :-1]
+    out_edges = out_edges_temp[..., :-1]
 
     # Specific calls to (wrapped) nb.guvectorize'd rebinning methods
     if method == "interpolation":
-        return _rebin_interpolation(in_spectra, in_edges, out_edges, slopes)
+        hist = _rebin_interpolation(in_spectra, in_edges, out_edges, slopes)
     elif method == "listmode":
-        return _rebin_listmode(in_spectra, in_edges, out_edges)
-    raise ValueError(f"{method} is not a valid rebinning method")
+        hist = _rebin_listmode(in_spectra, in_edges, out_edges)
+    else:
+        raise ValueError(f"{method} is not a valid rebinning method")
+
+    if not include_overflows:
+        hist = hist[..., 1:-1]
+    return hist

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -1252,7 +1252,12 @@ class Spectrum:
         return obj
 
     def rebin(
-        self, out_edges, method="interpolation", slopes=None, zero_pad_warnings=True
+        self,
+        out_edges,
+        method="interpolation",
+        slopes=None,
+        zero_pad_warnings=True,
+        include_overflows=False,
     ):
         """
         Spectra rebinning via deterministic or stochastic methods.
@@ -1269,8 +1274,11 @@ class Spectrum:
                 for quadratic interpolation
                 (only applies for "interpolation" method)
                 [len(spectrum) + 1]
-        zero_pad_warnings (boolean): warn when edge overlap results in
-            appending empty bins
+            zero_pad_warnings (boolean): warn when edge overlap results in
+                appending empty bins
+            include_overflows (boolean): whether to include counts below
+                out_edges[0] and above out_edges[-1] in the first and last
+                of the "out" bins, respectively, or to discard them (default).
 
         Raises:
             SpectrumError: for bad input arguments
@@ -1297,6 +1305,7 @@ class Spectrum:
             method=method,
             slopes=slopes,
             zero_pad_warnings=zero_pad_warnings,
+            include_overflows=include_overflows,
         )
         return Spectrum(
             counts=out_spec,

--- a/tests/rebin_test.py
+++ b/tests/rebin_test.py
@@ -274,3 +274,56 @@ class TestRebin:
             label="rebinned",
         )
         plt.show()
+
+
+@pytest.mark.parametrize(
+    "edges2, counts2, method, include_overflows",
+    [
+        (
+            np.linspace(2, 9, num=8),
+            np.array([3000, 1000, 1000, 1000, 1000, 1000, 2000]),
+            "interpolation",
+            True,
+        ),
+        (
+            np.linspace(2, 9, num=8),
+            np.array([1000, 1000, 1000, 1000, 1000, 1000, 1000]),
+            "interpolation",
+            False,
+        ),
+        (
+            np.linspace(2, 9, num=8),
+            np.array([3000, 1000, 1000, 1000, 1000, 1000, 2000]),
+            "listmode",
+            True,
+        ),
+        (
+            np.linspace(2, 9, num=8),
+            np.array([1000, 1000, 1000, 1000, 1000, 1000, 1000]),
+            "listmode",
+            False,
+        ),
+        (
+            np.linspace(2.5, 9.5, num=8),
+            np.array([3500, 1000, 1000, 1000, 1000, 1000, 1500]),
+            "interpolation",
+            True,
+        ),
+        (
+            np.linspace(2.5, 9.5, num=8),
+            np.array([1000, 1000, 1000, 1000, 1000, 1000, 1000]),
+            "interpolation",
+            False,
+        ),
+    ],
+)
+def test_rebin_include_overflows(edges2, counts2, method, include_overflows):
+    """Perform specific numerical rebinning tests."""
+
+    counts = 1000 * np.ones(10)
+    spec = bq.Spectrum(counts=counts)
+    cal = bq.Calibration("p[0] * x", [1.0])
+    spec.apply_calibration(cal)
+
+    spec2 = spec.rebin(edges2, method=method, include_overflows=include_overflows)
+    assert np.allclose(counts2, spec2.counts_vals)


### PR DESCRIPTION
This PR allows the user to specify whether "overflow" events are included in the leftmost and rightmost bins when rebinning. Changes the default to *not* including overflow events since it can lead to confusion (see #334).

The following MWE demonstrates the different functionality:

```python
import numpy as np
import becquerel as bq

counts = 1000 * np.ones(10)
spec = bq.Spectrum(counts=counts)
cal = bq.Calibration("p[0] * x", [1.0])
spec.apply_calibration(cal)
print("Original spectrum:")
print("edges: ", spec.bin_edges_kev)
print("values:", spec.counts_vals)

for edges in [
    np.linspace(2, 9, num=8),
    np.linspace(2.5, 9.5, num=8),
]:
    for method in ["interpolation", "listmode"]:
        for include_overflows in [True, False]:
            spec2 = spec.rebin(edges, method=method, include_overflows=include_overflows)
            print("")
            print(f"Rebinned spectrum (method={method}, include_overflows={include_overflows}):")
            print("edges: ", spec2.bin_edges_kev)
            print("values:", spec2.counts_vals)
```

The output is:

```
Original spectrum:
edges:  [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10.]
values: [1000. 1000. 1000. 1000. 1000. 1000. 1000. 1000. 1000. 1000.]

Rebinned spectrum (method=interpolation, include_overflows=True):
edges:  [2. 3. 4. 5. 6. 7. 8. 9.]
values: [3000. 1000. 1000. 1000. 1000. 1000. 2000.]

Rebinned spectrum (method=interpolation, include_overflows=False):
edges:  [2. 3. 4. 5. 6. 7. 8. 9.]
values: [1000. 1000. 1000. 1000. 1000. 1000. 1000.]

Rebinned spectrum (method=listmode, include_overflows=True):
edges:  [2. 3. 4. 5. 6. 7. 8. 9.]
values: [3000. 1000. 1000. 1000. 1000. 1000. 2000.]

Rebinned spectrum (method=listmode, include_overflows=False):
edges:  [2. 3. 4. 5. 6. 7. 8. 9.]
values: [1000. 1000. 1000. 1000. 1000. 1000. 1000.]

Rebinned spectrum (method=interpolation, include_overflows=True):
edges:  [2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5]
values: [3500. 1000. 1000. 1000. 1000. 1000. 1500.]

Rebinned spectrum (method=interpolation, include_overflows=False):
edges:  [2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5]
values: [1000. 1000. 1000. 1000. 1000. 1000. 1000.]

Rebinned spectrum (method=listmode, include_overflows=True):
edges:  [2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5]
values: [3519.  991. 1001.  971. 1027. 1018. 1473.]

Rebinned spectrum (method=listmode, include_overflows=False):
edges:  [2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5]
values: [1017.  992. 1015. 1000.  996. 1017.  972.]
```

Fixes #334