### PR TITLE
Do not cancel other tests if there is a failure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-20.04", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         os: ["macos-latest", "ubuntu-20.04", "windows-latest"]
         python-version: ["3.6", "3.7", "3.8", "3.9"]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     # Installation and testing


### PR DESCRIPTION
Some of the tests remain flaky, and by default all of the running tests get canceled if there is one failure. This change is an attempt to keep the tests running.