### PR TITLE
Handle UNIX timestamps in `handle_datetime`

### DIFF
--- a/becquerel/core/utils.py
+++ b/becquerel/core/utils.py
@@ -3,6 +3,7 @@
 import datetime
 from dateutil.parser import parse as dateutil_parse
 from dateutil.parser import ParserError
+from numbers import Number
 from uncertainties import UFloat, unumpy
 import warnings
 import numpy as np
@@ -101,6 +102,8 @@ def handle_datetime(input_time, error_name="datetime arg", allow_none=False):
             "datetime.date passed in with no time; defaulting to 0:00 on date"
         )
         return datetime.datetime(input_time.year, input_time.month, input_time.day)
+    elif isinstance(input_time, Number):
+        return datetime.datetime.fromtimestamp(input_time)
     elif isinstance(input_time, str):
         try:
             return dateutil_parse(input_time)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -52,10 +52,7 @@ def test_handle_datetime_None():
 
 @pytest.mark.parametrize(
     "arg,error_type",
-    [
-        ("2023_06_14-08_01_02", ValueError),
-        (2022, TypeError),
-    ],
+    [("2023_06_14-08_01_02", ValueError)],
 )
 def test_handle_datetime_err(arg, error_type):
     with pytest.raises(error_type):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -36,6 +36,7 @@ def test_sqrt_bins():
         datetime.datetime(year=2023, month=6, day=14, hour=0, minute=0, second=0),
         "2023_06_14_00_00_00",
         "2023-06-14T00:00:00.000Z-0000",  # ISO 8601, with timezone
+        1686726000.0,  # UNIX timestamp
     ],
 )
 def test_handle_datetime(timestamp):


### PR DESCRIPTION
Passing a UNIX timestamp like `1686726000.0` to `handle_datetime` currently gives an error, but we can parse it with `datetime.fromtimestamp`.