### PR TITLE
Fix nndc._request()

### DIFF
--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -436,7 +436,7 @@ class _NNDCQuery:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=ResourceWarning)
                 resp = session.post(self._URL, data=self._data, stream=False)
-            if not resp.ok or resp.reason != "OK" or resp.status_code != 200:
+            if not resp.ok or resp.status_code != 200:
                 raise NNDCRequestError("Request failed: " + resp.reason)
             for msg in [
                 "Your search was unsuccessful",


### PR DESCRIPTION
As of about two weeks ago, requesting data from .jsp sites (like https://www.nndc.bnl.gov/nudat3/sigma_searchi.jsp) for wallet card and decay data information began returning empty request errors: "NNDCRequestError: Request failed: "

![image](https://github.com/lbl-anp/becquerel/assets/68420646/3cad677b-7a91-425f-87ed-5504ddd681d5)

After speaking with a Technology Analyst at Brookhaven, they concluded a few things. sigma_searchi.jsp provides a response object with "ok == True" and "status_code == 200". It's "reason" field is set to an empty string instead of "OK". In line 439, the 'resp.reason != "OK"' condition causes _request() to fail, despite NNDC returning data. Removing this condition fixes it and returns data successfully.

![image](https://github.com/lbl-anp/becquerel/assets/68420646/498b829a-a127-4bb5-a6f1-aeeb0b33435d)
