### PR TITLE
update assert messages in materials_test.py

### DIFF
--- a/becquerel/tools/materials_nist.py
+++ b/becquerel/tools/materials_nist.py
@@ -9,6 +9,7 @@ References:
 
 import requests
 import pandas as pd
+from io import StringIO
 from collections.abc import Iterable
 from .element import element_symbol
 from .materials_error import MaterialsError
@@ -77,7 +78,7 @@ def fetch_element_data():
     # remove open <TR> at the end of the table
     text = text.replace("</TD></TR><TR>", "</TD></TR>")
     # read HTML table into pandas DataFrame
-    tables = pd.read_html(text, header=0, skiprows=[1, 2])
+    tables = pd.read_html(StringIO(text), header=0, skiprows=[1, 2])
     if len(tables) != 1:
         raise MaterialsError(f"1 HTML table expected, but found {len(tables)}")
     df = tables[0]
@@ -162,7 +163,7 @@ def fetch_compound_data():
     # replace <BR> symbols in composition lists with semicolons
     text = text.replace("<BR>", ";")
     # read HTML table into pandas DataFrame
-    tables = pd.read_html(text, header=0, skiprows=[1, 2])
+    tables = pd.read_html(StringIO(text), header=0, skiprows=[1, 2])
     if len(tables) != 1:
         raise MaterialsError(f"1 HTML table expected, but found {len(tables)}")
     df = tables[0]

--- a/tests/materials_test.py
+++ b/tests/materials_test.py
@@ -68,9 +68,13 @@ def test_materials_force():
     with pytest.warns(MaterialsWarning) as record:
         fetch_materials(force=True)
     if not os.path.exists(materials_compendium.FNAME):
-        assert len(record) == 2, "Expected two MaterialsWarnings to be raised"
+        assert (
+            len(record) == 2
+        ), f"Expected two MaterialsWarnings to be raised; got {record}"
     else:
-        assert len(record) == 1, "Expected one MaterialsWarning to be raised"
+        assert (
+            len(record) == 1
+        ), f"Expected one MaterialsWarning to be raised; got {record}"
     assert os.path.exists(materials.FILENAME)
 
 
@@ -130,7 +134,7 @@ def test_materials_dummy_compendium_pre2022():
         json.dump(data, f, indent=4)
     with pytest.warns(None) as record:
         materials._load_and_compile_materials()
-    assert len(record) == 0, "Expected no MaterialsWarnings to be raised"
+    assert len(record) == 0, f"Expected no MaterialsWarnings to be raised; got {record}"
     # remove the dummy file and point back to original
     os.remove(materials_compendium.FNAME)
     materials_compendium.FNAME = fname_orig
@@ -179,7 +183,7 @@ def test_materials_dummy_compendium_2022():
         json.dump(data, f, indent=4)
     with pytest.warns(None) as record:
         materials._load_and_compile_materials()
-    assert len(record) == 0, "Expected no MaterialsWarnings to be raised"
+    assert len(record) == 0, f"Expected no MaterialsWarnings to be raised; got {record}"
     # remove siteVersion and make sure there is an error raised
     del data["siteVersion"]
     with open(materials_compendium.FNAME, "w") as f:
@@ -222,7 +226,7 @@ def test_materials_no_compendium():
         os.remove(materials_compendium.FNAME)
     with pytest.warns(MaterialsWarning) as record:
         materials_compendium.fetch_compendium_data()
-    assert len(record) == 1, "Expected MaterialsWarning to be raised"
+    assert len(record) == 1, f"Expected one MaterialsWarning to be raised; got {record}"
     # point back to original file
     materials_compendium.FNAME = fname_orig
 

--- a/tests/materials_test.py
+++ b/tests/materials_test.py
@@ -15,6 +15,10 @@ import pytest
 from utils import xcom_is_up
 
 
+def _get_warning_messages(record):
+    return [str(rec.message) for rec in record]
+
+
 @pytest.mark.webtest
 @pytest.mark.skipif(not xcom_is_up(), reason="XCOM is down.")
 class TestConvertComposition:
@@ -68,13 +72,15 @@ def test_materials_force():
     with pytest.warns(MaterialsWarning) as record:
         fetch_materials(force=True)
     if not os.path.exists(materials_compendium.FNAME):
-        assert (
-            len(record) == 2
-        ), f"Expected two MaterialsWarnings to be raised; got {record}"
+        assert len(record) == 2, (
+            "Expected two MaterialsWarnings to be raised; "
+            f"got {_get_warning_messages(record)}"
+        )
     else:
-        assert (
-            len(record) == 1
-        ), f"Expected one MaterialsWarning to be raised; got {record}"
+        assert len(record) == 1, (
+            "Expected one MaterialsWarning to be raised; "
+            f"got {_get_warning_messages(record)}"
+        )
     assert os.path.exists(materials.FILENAME)
 
 
@@ -134,7 +140,10 @@ def test_materials_dummy_compendium_pre2022():
         json.dump(data, f, indent=4)
     with pytest.warns(None) as record:
         materials._load_and_compile_materials()
-    assert len(record) == 0, f"Expected no MaterialsWarnings to be raised; got {record}"
+    assert len(record) == 0, (
+        "Expected no MaterialsWarnings to be raised; "
+        f"got {_get_warning_messages(record)}"
+    )
     # remove the dummy file and point back to original
     os.remove(materials_compendium.FNAME)
     materials_compendium.FNAME = fname_orig
@@ -183,7 +192,10 @@ def test_materials_dummy_compendium_2022():
         json.dump(data, f, indent=4)
     with pytest.warns(None) as record:
         materials._load_and_compile_materials()
-    assert len(record) == 0, f"Expected no MaterialsWarnings to be raised; got {record}"
+    assert len(record) == 0, (
+        "Expected no MaterialsWarnings to be raised; "
+        f"got {_get_warning_messages(record)}"
+    )
     # remove siteVersion and make sure there is an error raised
     del data["siteVersion"]
     with open(materials_compendium.FNAME, "w") as f:
@@ -226,7 +238,10 @@ def test_materials_no_compendium():
         os.remove(materials_compendium.FNAME)
     with pytest.warns(MaterialsWarning) as record:
         materials_compendium.fetch_compendium_data()
-    assert len(record) == 1, f"Expected one MaterialsWarning to be raised; got {record}"
+    assert len(record) == 1, (
+        "Expected one MaterialsWarning to be raised; "
+        f"got {_get_warning_messages(record)}"
+    )
     # point back to original file
     materials_compendium.FNAME = fname_orig
 


### PR DESCRIPTION
This shows that the extra messages are of the form:
```
FAILED tests/materials_test.py::test_materials_dummy_compendium_2022 - AssertionError: Expected no MaterialsWarnings to be raised; got ["Passing literal html to 'read_html' is deprecated and will be removed in a future version. To read from a literal string, wrap it in a 'StringIO' object.", "Passing literal html to 'read_html' is deprecated and will be removed in a future version. To read from a literal string, wrap it in a 'StringIO' object."]
```