### PR TITLE
Address a FutureWarning from pandas

### DIFF
--- a/becquerel/tools/xcom.py
+++ b/becquerel/tools/xcom.py
@@ -9,6 +9,7 @@ References:
 
 """
 
+from io import StringIO
 import requests
 import pandas as pd
 from collections.abc import Iterable
@@ -398,7 +399,7 @@ class _XCOMQuery:
         self._text = str(self._req.text)
         if len(self._text) == 0:
             raise XCOMRequestError("XCOM returned no text")
-        tables = pd.read_html(self._text, header=0, skiprows=[1, 2])
+        tables = pd.read_html(StringIO(self._text), header=0, skiprows=[1, 2])
         if len(tables) != 1:
             raise XCOMRequestError("More than one HTML table found")
         self.df = tables[0]


### PR DESCRIPTION
This change removes the following warning that occurs when querying XCOM data:

```
becquerel/tools/xcom.py:403: FutureWarning: Passing literal html to 'read_html' is deprecated and will be removed in a future version. To read from a literal string, wrap it in a 'StringIO' object.
  tables = pd.read_html(self._text, header=0, skiprows=[1, 2])
```