### PR TITLE
Add codespell to pre-commit and fix spelling errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,14 @@ repos:
     hooks:
       - id: bandit
         args: [--skip, "B101"]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+        args: [
+            "--ignore-words-list=livetime,Te,te,Nb,nd,FOM,fom",
+            '--ignore-regex=^\s*"image\/png":\s.*', # ignore jupyter notebook images
+          ]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.39.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,16 @@ pre-commit install
 from the installation directory, and the installed package will always use
 the current version of code.)
 
-We use [`pre-commit`](https://pre-commit.com/) to automatically run black.
+## Linting, formatting, and other checks
+
+We use [`pre-commit`](https://pre-commit.com/) to automatically run various
+checks and formatting tools in the CI.
+If `pre-commit` is installed, it will automatically run when committing
+new code, and it can also be run at any time using the following command:
+
+```bash
+pre-commit run --all
+```
 
 ### Running the tests
 
@@ -48,21 +57,14 @@ pytest --cov-report html:htmlcov
 
 ## Code Style Guide
 
-Use [google standards](https://google.github.io/styleguide/pyguide.html)
-
-## Linter
-
-The code style/formatting will be checked with
-[`black`](https://black.readthedocs.io/en/stable/) and
-[`flake8`](https://flake8.pycqa.org/en/latest/) in the CI
+Use [google standards](https://google.github.io/styleguide/pyguide.html).
 
 ## Checklist for code contributions
 
 - [ ] Branch off of `main`
 - [ ] Develop the feature or fix
 - [ ] Write tests to cover all use cases
+- [ ] Ensure all checks pass (`pre-commit`)
 - [ ] Ensure all tests pass (`pytest`)
 - [ ] Ensure test coverage is >95%
-- [ ] Autoformat (`black .`)
-- [ ] Spellcheck your code and docstrings
 - [ ] Push branch to GitHub and create a pull request to `main`

--- a/becquerel/core/peakfinder.py
+++ b/becquerel/core/peakfinder.py
@@ -361,7 +361,7 @@ class PeakFinder:
             Right edge of the x-range that should be scanned for
             peaks. Uses max(x-range) if not given.
         min_snr
-            Minium SNR for a peak to be added
+            Minimum SNR for a peak to be added
         max_num
             Maximum number of peaks to be added
         reset

--- a/becquerel/core/plotting.py
+++ b/becquerel/core/plotting.py
@@ -25,9 +25,9 @@ class SpectrumPlotter:
           ylim:   set y axes limits, if set to 'default' use special scales
           ax:     matplotlib axes object, if not provided one is created using
           yscale: matplotlib scale: 'linear', 'log', 'logit', 'symlog'
-          title:  costum plot title, default is filename if available
-          xlabel: costum xlabel value
-          ylabel: costum ylabel value
+          title:  custom plot title, default is filename if available
+          xlabel: custom xlabel value
+          ylabel: custom ylabel value
           kwargs: arguments that are directly passed to matplotlib's plot command.
                   In addition it is possible to pass linthresh if ylim='default'
                   and ymode='symlog'
@@ -190,7 +190,7 @@ class SpectrumPlotter:
     @xlabel.setter
     def xlabel(self, label):
         """
-        Sets the xlabel to a costum value.
+        Sets the xlabel to a custom value.
         """
 
         if label is not None:
@@ -207,7 +207,7 @@ class SpectrumPlotter:
     @ylabel.setter
     def ylabel(self, label):
         """
-        Sets the ylabel to a costum value.
+        Sets the ylabel to a custom value.
         """
 
         if label is not None:

--- a/becquerel/core/rebin.py
+++ b/becquerel/core/rebin.py
@@ -289,7 +289,7 @@ def rebin(
     Spectra rebinning via deterministic or stochastic methods.
 
     Args:
-        in_spectrum (np.ndarray): an ND array of input counts spectra
+        in_spectrum (np.ndarray): an ndarray of input counts spectra
             [..., num_bins_in]
         in_edges (np.ndarray): an array of the input bin edges
             [..., num_bins_in + 1] or [num_bins_in + 1] (either contains

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -1389,9 +1389,9 @@ class Spectrum:
           ylim:   set y axes limits, if set to 'default' use special scales
           ax:     matplotlib axes object, if not provided one is created
           yscale: matplotlib scale: 'linear', 'log', 'logit', 'symlog'
-          title:  costum plot title
-          xlabel: costum xlabel value
-          ylabel: costum ylabel value
+          title:  custom plot title
+          xlabel: custom xlabel value
+          ylabel: custom ylabel value
           emode:  can be 'band' for adding an erroband or 'bars' for adding
                   error bars, default is 'none'. It herits the color from
                   matplotlib plot and can not be configured. For better
@@ -1433,9 +1433,9 @@ class Spectrum:
           ylim:   set y axes limits, if set to 'default' use special scales
           ax:     matplotlib axes object, if not provided one is created
           yscale: matplotlib scale: 'linear', 'log', 'logit', 'symlog'
-          title:  costum plot title
-          xlabel: costum xlabel value
-          ylabel: costum ylabel value
+          title:  custom plot title
+          xlabel: custom xlabel value
+          ylabel: custom ylabel value
           kwargs: arguments that are directly passed to matplotlib's
                   fill_between command. In addition it is possible to pass
                   linthresh if ylim='default' and ymode='symlog'.

--- a/becquerel/tools/_nndc_dummy_text.py
+++ b/becquerel/tools/_nndc_dummy_text.py
@@ -7,7 +7,7 @@ _NUCLEAR_WALLET_CARD_QUERY_DUMMY_TEXT = """
 <pre>
 A  	Element	Z  	N  	Energy  	JPi           	Mass Exc  	Unc  	T1/2 (txt)               	T1/2 (seconds)           	Abund.    	Unc     	Dec Mode	Branching (%)
 
- To save this output into a local file, clik on "File" in your browser menu and select "Save as"
+ To save this output into a local file, click on "File" in your browser menu and select "Save as"
 
 </pre></body></html>
 """
@@ -19,7 +19,7 @@ _DECAY_RADIATION_QUERY_DUMMY_TEXT = """
 A  	Element	Z  	N  	Par. Elevel	Unc. 	JPi       	Dec Mode	T1/2 (txt)    	T1/2 (num)        	Daughter	Radiation	Rad subtype 	Rad Ene.  	Unc       	EP Ene.   	Unc       	Rad Int.  	Unc       	Dose        	Unc
 
 </pre>
-To save this output into a local File, clik on "File" in your browser menu and select "Save as"
+To save this output into a local File, click on "File" in your browser menu and select "Save as"
 </body></html>
 """
 

--- a/examples/autocal.ipynb
+++ b/examples/autocal.ipynb
@@ -1096,7 +1096,7 @@
    "source": [
     "## Example 4: CsI detector with Ba-133 and Cs-137 sources\n",
     "\n",
-    "This data is from a small detector with Ba-133 and Cs-137 sources near it. We want to use those sources' lines and any strong backgroud lines to calibrate it."
+    "This data is from a small detector with Ba-133 and Cs-137 sources near it. We want to use those sources' lines and any strong background lines to calibrate it."
    ]
   },
   {

--- a/examples/energycal.ipynb
+++ b/examples/energycal.ipynb
@@ -53,7 +53,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "becquerel/parsers/spectrum_file.py:137: SpectrumFileParsingWarning: Spectrum will be initated without an energy calibration;invalid calibration, energies not monotonically increasing.\n",
+      "becquerel/parsers/spectrum_file.py:137: SpectrumFileParsingWarning: Spectrum will be initialized without an energy calibration; invalid calibration, energies not monotonically increasing.\n",
       "  warnings.warn(\n"
      ]
     }
@@ -222,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The coefficents are automatically fit to those points:"
+    "The coefficients are automatically fit to those points:"
    ]
   },
   {

--- a/examples/overview.ipynb
+++ b/examples/overview.ipynb
@@ -12,7 +12,7 @@
     "  - [Constructor](#1.1-From-scratch)\n",
     "  - [Energy Calibration Models](#1.2-Energy-Calibration-Models)\n",
     "  - [File IO](#1.3-From-File)\n",
-    "  - [Backrgound Subtraction](#1.4-Background-Subtraction)\n",
+    "  - [Background Subtraction](#1.4-Background-Subtraction)\n",
     "  - [Rebinning](#1.5-Rebinning)\n",
     "  - [Scaling](#1.6-Scaling)\n",
     "  - [Peak Finding + Auto Calibration](#1.7-Automatic-Calibration)\n",
@@ -830,7 +830,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/msbandstra/Dropbox/Projects/Becquerel/becquerel/becquerel/parsers/spectrum_file.py:137: SpectrumFileParsingWarning: Spectrum will be initated without an energy calibration;invalid calibration, energies not monotonically increasing.\n",
+      "/Users/msbandstra/Dropbox/Projects/Becquerel/becquerel/becquerel/parsers/spectrum_file.py:137: SpectrumFileParsingWarning: Spectrum will be initialized without an energy calibration; invalid calibration, energies not monotonically increasing.\n",
       "  warnings.warn(\n"
      ]
     },

--- a/examples/rebinning.ipynb
+++ b/examples/rebinning.ipynb
@@ -263,7 +263,7 @@
    "source": [
     "## Usage with other packages than numpy\n",
     "\n",
-    "The rebin module can also be used with other packages such as `xarray`. But there is a bit more code involved to apply the rebinning alogrithm in parallel as a `ufunc`. Also this doesn't perform any tests on the inputs. Lets first create a `xarray` data set. For this the `xarray` package needs to be installed."
+    "The rebin module can also be used with other packages such as `xarray`. But there is a bit more code involved to apply the rebinning algorithm in parallel as a `ufunc`. Also this doesn't perform any tests on the inputs. Lets first create a `xarray` data set. For this the `xarray` package needs to be installed."
    ]
   },
   {
@@ -324,7 +324,7 @@
    "source": [
     "It is important to note that the last element in the `out_edges` array was omitted in the input. This is necessary to used the `_rebin_interpolate` and `_rebin_listmode` methods directly.\n",
     "\n",
-    "Simlarly, also the 'listmode' binning can be applied. The differences to the above sample originates from the randomness of the 'listmode' binning method."
+    "Similarly, the 'listmode' binning can also be applied. The differences to the above sample originates from the randomness of the 'listmode' binning method."
    ]
   },
   {

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -370,7 +370,7 @@ def test_error_positional_parameters(cal_spec):
 
 
 def test_uncal_as_cal(uncal_spec):
-    """Test errors for calibrated reqested for an uncalibrated spectrum"""
+    """Test errors for calibrated requested for an uncalibrated spectrum"""
 
     with pytest.raises(bq.PlottingError):
         uncal_spec.plot(xmode="energy")


### PR DESCRIPTION
Title says it all. Also updates the contributor guidelines to reflect the need to run `pre-commit` and not just `black`.