### PR TITLE
Enable pylint and other linting rules in ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
     rev: v0.4.5
     hooks:
       - id: ruff
+        args: ["--preview"]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
@@ -56,4 +57,4 @@ repos:
         args: [--nbqa-dont-skip-bad-cells]
       - id: nbqa-ruff
         additional_dependencies: [ruff==v0.4.5]
-        args: ["--ignore=E722,F821,S110"]
+        args: ["--ignore=E722,F821,S110", "--preview"]

--- a/becquerel/core/calibration.py
+++ b/becquerel/core/calibration.py
@@ -149,9 +149,9 @@ def _eval_expression(
         if y_low and y_high:
             msg = msg + msg_low + " and " + msg_high
         elif y_low:
-            msg = msg + msg_low
+            msg += msg_low
         else:
-            msg = msg + msg_high
+            msg += msg_high
         warnings.warn(msg, CalibrationWarning)
     return y
 

--- a/becquerel/core/calibration.py
+++ b/becquerel/core/calibration.py
@@ -240,9 +240,8 @@ def _validate_expression(
         raise CalibrationError(f"Independent variable {ind_var} must be 'x' or 'y'")
     ind_var_appears = False
     for node in ast.walk(ast.parse(expression)):
-        if type(node) is ast.Name:
-            if node.id == ind_var:
-                ind_var_appears = True
+        if type(node) is ast.Name and node.id == ind_var:
+            ind_var_appears = True
     if not ind_var_appears:
         raise CalibrationError(
             f'Independent variable "{ind_var}" must appear in the expression:\n'
@@ -267,12 +266,11 @@ def _validate_expression(
                 "Parameter indices in expression are not contiguous:\n"
                 f"{expression}\n{param_indices}"
             )
-    if params is not None:
-        if len(param_indices) != len(params):
-            raise CalibrationError(
-                "Not enough parameter indices in expression:\n"
-                f"{expression}\n{param_indices}"
-            )
+    if params is not None and len(param_indices) != len(params):
+        raise CalibrationError(
+            "Not enough parameter indices in expression:\n"
+            f"{expression}\n{param_indices}"
+        )
 
     # make sure the expression can be evaluated
     if params is not None:

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -693,7 +693,7 @@ class Fitter:
         raise FittingError(f"Unknown model type: {m}")
 
     def _make_model(self, model):
-        if isinstance(model, str) or isinstance(model, Model):
+        if isinstance(model, (str, Model)):
             model = [model]
         # Convert the model(s) to a list of Model classes / Model instancess
         self._model_cls_cnt = {}
@@ -750,10 +750,9 @@ class Fitter:
 
     def guess_param_defaults(self, update=False, **kwargs):
         defaults = self._guess_param_defaults(**kwargs)
-        if update:
-            if defaults is not None:
-                for dp in defaults:
-                    self.set_param(*dp)
+        if update and defaults is not None:
+            for dp in defaults:
+                self.set_param(*dp)
         return defaults
 
     def fit(self, backend="lmfit", guess=None, limits=None):
@@ -871,9 +870,7 @@ class Fitter:
                         min_vals[lim[0]] = lim[2]
                     elif lim[1] == "max":
                         max_vals[lim[0]] = lim[2]
-                limits_i = {
-                    p: (min_vals.get(p, None), max_vals.get(p, None)) for p in free_vars
-                }
+                limits_i = {p: (min_vals.get(p), max_vals.get(p)) for p in free_vars}
             except NotImplementedError:
                 # If the model/component does not have a guess() method
                 limits_i = {}

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -203,9 +203,7 @@ def _is_count_like(y):
     """
     if np.any(y < 0):
         return False
-    if not np.allclose(np.rint(y).astype(int), y):
-        return False
-    return True
+    return np.allclose(np.rint(y).astype(int), y)
 
 
 class ConstantModel(Model):
@@ -806,7 +804,7 @@ class Fitter:
                 self.params,  # self.result.params,
                 x=self.x_roi,
                 weights=self.dx_roi,
-                fit_kws={"reduce_fcn": lambda r: np.sum(r)},
+                fit_kws={"reduce_fcn": np.sum},
                 method="Nelder-Mead",
                 calc_covar=False,
             )  # no, bounds, default would be L-BFGS-B'

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -1435,8 +1435,8 @@ class Fitter:
             # Add info about the ROI and units
             if self.roi:
                 s += "ROI: [{:.3f}, {:.3f}]\n".format(*self.roi)
-            s += "X units: {:s}\n".format(self.xmode if self.xmode else "None")
-            s += "Y units: {:s}\n".format(self.ymode if self.ymode else "None")
+            s += "X units: {:s}\n".format(self.xmode or "None")
+            s += "Y units: {:s}\n".format(self.ymode or "None")
             # Add to empty axis
             txt_ax.text(
                 x=0.01,

--- a/becquerel/core/plotting.py
+++ b/becquerel/core/plotting.py
@@ -94,18 +94,17 @@ class SpectrumPlotter:
                 self._xmode = "energy"
             else:
                 self._xmode = "channel"
+        elif mode.lower() in ("kev", "energy"):
+            if not self.spec.is_calibrated:
+                raise PlottingError(
+                    "Spectrum is not calibrated, however "
+                    "x axis was requested as energy"
+                )
+            self._xmode = "energy"
+        elif mode.lower() in ("channel", "channels", "chn", "chns"):
+            self._xmode = "channel"
         else:
-            if mode.lower() in ("kev", "energy"):
-                if not self.spec.is_calibrated:
-                    raise PlottingError(
-                        "Spectrum is not calibrated, however "
-                        "x axis was requested as energy"
-                    )
-                self._xmode = "energy"
-            elif mode.lower() in ("channel", "channels", "chn", "chns"):
-                self._xmode = "channel"
-            else:
-                raise PlottingError(f"Unknown x data mode: {mode}")
+            raise PlottingError(f"Unknown x data mode: {mode}")
 
         # Then, set the _xedges and _xlabel based on the _xmode
         xedges, xlabel = self.spec.parse_xmode(self._xmode)

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -985,13 +985,12 @@ class Spectrum:
                 or np.isnan(scaling_factor)
             ):
                 raise ValueError("Scaling factor must be nonzero and finite")
-        else:
-            if (
-                scaling_factor.nominal_value == 0
-                or np.isinf(scaling_factor.nominal_value)
-                or np.isnan(scaling_factor.nominal_value)
-            ):
-                raise ValueError("Scaling factor must be nonzero and finite")
+        elif (
+            scaling_factor.nominal_value == 0
+            or np.isinf(scaling_factor.nominal_value)
+            or np.isnan(scaling_factor.nominal_value)
+        ):
+            raise ValueError("Scaling factor must be nonzero and finite")
         if div:
             multiplier = 1 / scaling_factor
         else:
@@ -1481,7 +1480,7 @@ class Spectrum:
         color = ax.get_lines()[-1].get_color()
         if emode == "band":
             plotter.errorband(color=color, alpha=alpha * 0.5, label="_nolegend_")
-        elif emode == "bars" or emode == "bar":
+        elif emode in ("bars", "bar"):
             plotter.errorbar(color=color, label="_nolegend_")
         elif emode != "none":
             raise SpectrumError(f"Unknown error mode '{emode}', use 'bars' or 'band'")

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -942,7 +942,7 @@ class Spectrum:
     # This line adds the right multiplication
     __rmul__ = __mul__
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         """Return a new Spectrum object with counts (or CPS) scaled down.
 
         Args:
@@ -957,9 +957,6 @@ class Spectrum:
         """
 
         return self._mul_div(other, div=True)
-
-    # This line adds true division
-    __truediv__ = __div__
 
     def _mul_div(self, scaling_factor: float, div=False):
         """Multiply or divide a spectrum by a scalar. Handle errors.

--- a/becquerel/io/h5.py
+++ b/becquerel/io/h5.py
@@ -101,7 +101,7 @@ def write_h5(name: str | h5py.File | h5py.Group, dsets: dict, attrs: dict) -> No
     """
     with open_h5(name, "w") as file:
         # write the datasets
-        for key in dsets.keys():
+        for key in dsets:
             try:
                 file.create_dataset(
                     key,
@@ -137,7 +137,7 @@ def read_h5(name: str | h5py.File | h5py.Group) -> tuple[dict, dict, list]:
     skipped = []
     with open_h5(name, "r") as file:
         # read the datasets
-        for key in file.keys():
+        for key in file:
             # skip any non-datasets
             if not isinstance(file[key], h5py.Dataset):
                 skipped.append(str(key))

--- a/becquerel/parsers/cnf.py
+++ b/becquerel/parsers/cnf.py
@@ -296,7 +296,7 @@ def read(filename, verbose=False, cal_kwargs=None):
     data["counts"] = counts
 
     # clean up null characters in any strings
-    for key in data.keys():
+    for key in data:
         if isinstance(data[key], str):
             data[key] = data[key].replace("\x00", " ")
             data[key] = data[key].replace("\x01", " ")

--- a/becquerel/parsers/iec1455.py
+++ b/becquerel/parsers/iec1455.py
@@ -95,7 +95,7 @@ def read(filename, verbose=False, cal_kwargs=None):
     energy_channel_pairs = []
     energy_res_pairs = []  # currently unused
     energy_eff_pairs = []  # currently unused
-    with Path(filename).open() as f:
+    with Path(filename).open(encoding="utf-8") as f:
         record = 1
         # loop over lines
         for line in f:

--- a/becquerel/parsers/spc.py
+++ b/becquerel/parsers/spc.py
@@ -392,7 +392,7 @@ def read(filename, verbose=False, cal_kwargs=None):
         raise BecquerelParserError("Calibration parameters not found") from exc
 
     # clean up null characters in any strings
-    for key in data.keys():
+    for key in data:
         if isinstance(data[key], str):
             data[key] = data[key].replace("\x00", " ")
             data[key] = data[key].replace("\x01", " ")

--- a/becquerel/parsers/spe.py
+++ b/becquerel/parsers/spe.py
@@ -48,7 +48,7 @@ def read(filename, verbose=False, cal_kwargs=None):
     counts = []
     channels = []
     cal_coeff = []
-    with Path(filename).open() as f:
+    with Path(filename).open(encoding="utf-8") as f:
         # read & remove newlines from end of each line
         lines = [line.strip() for line in f]
         i = 0

--- a/becquerel/parsers/spe.py
+++ b/becquerel/parsers/spe.py
@@ -97,9 +97,8 @@ def read(filename, verbose=False, cal_kwargs=None):
                 while i < len(lines) and not lines[i].startswith("$"):
                     values.append(lines[i])
                     i += 1
-                if i < len(lines):
-                    if lines[i].startswith("$"):
-                        i -= 1
+                if i < len(lines) and lines[i].startswith("$"):
+                    i -= 1
                 if len(values) == 1:
                     values = values[0]
                 data[key] = values

--- a/becquerel/tools/isotope.py
+++ b/becquerel/tools/isotope.py
@@ -235,35 +235,31 @@ class Isotope(element.Element):
         if arg == "" or arg is None or arg == 0:
             self.m = ""
             self.M = 0
-        else:
-            if isinstance(arg, int):
-                if arg == 1:
-                    self.m = "m"
-                    self.M = 1
-                elif arg >= 2:
-                    self.M = arg
-                    self.m = f"m{self.M}"
-                else:
-                    raise IsotopeError(f"Metastable level must be >= 0: {arg}")
-            elif isinstance(arg, str):
-                self.m = arg.lower()
-                if self.m[0] != "m":
-                    raise IsotopeError(
-                        f'Metastable level must start with "m": {self.m}'
-                    )
-                if len(self.m) > 1:
-                    if not self.m[1:].isdigit():
-                        raise IsotopeError(
-                            "Metastable level must be numeric: "
-                            f"{self.m[0]} {self.m[1:]}"
-                        )
-                    self.M = int(self.m[1:])
-                else:
-                    self.M = 1
+        elif isinstance(arg, int):
+            if arg == 1:
+                self.m = "m"
+                self.M = 1
+            elif arg >= 2:
+                self.M = arg
+                self.m = f"m{self.M}"
             else:
-                raise IsotopeError(
-                    f"Metastable level must be integer or string: {arg} {type(arg)}"
-                )
+                raise IsotopeError(f"Metastable level must be >= 0: {arg}")
+        elif isinstance(arg, str):
+            self.m = arg.lower()
+            if self.m[0] != "m":
+                raise IsotopeError(f'Metastable level must start with "m": {self.m}')
+            if len(self.m) > 1:
+                if not self.m[1:].isdigit():
+                    raise IsotopeError(
+                        f"Metastable level must be numeric: {self.m[0]} {self.m[1:]}"
+                    )
+                self.M = int(self.m[1:])
+            else:
+                self.M = 1
+        else:
+            raise IsotopeError(
+                f"Metastable level must be integer or string: {arg} {type(arg)}"
+            )
 
     def __str__(self):
         """Define behavior of str() on Isotope."""

--- a/becquerel/tools/isotope.py
+++ b/becquerel/tools/isotope.py
@@ -370,9 +370,8 @@ class Isotope(element.Element):
 
         df = self._wallet_card()
         data = df["Abundance (%)"].tolist()
-        if not isinstance(data[0], uncertainties.core.Variable):
-            if np.isnan(data[0]):
-                return None
+        if not isinstance(data[0], uncertainties.core.Variable) and np.isnan(data[0]):
+            return None
         return data[0]
 
     @property
@@ -411,9 +410,8 @@ class Isotope(element.Element):
 
         df = self._wallet_card()
         data = df["Mass Excess (MeV)"].tolist()
-        if not isinstance(data[0], uncertainties.core.Variable):
-            if np.isnan(data[0]):
-                return None
+        if not isinstance(data[0], uncertainties.core.Variable) and np.isnan(data[0]):
+            return None
         return data[0]
 
     @property

--- a/becquerel/tools/isotope_qty.py
+++ b/becquerel/tools/isotope_qty.py
@@ -512,13 +512,8 @@ class IsotopeQuantity:
 
         return self._mul_div(other, div=False)
 
-    def __div__(self, other):
-        """Divide the quantity"""
-
-        return self._mul_div(other, div=True)
-
     def __truediv__(self, other):
-        """Divide the quantity (python 3)"""
+        """Divide the quantity"""
 
         return self._mul_div(other, div=True)
 

--- a/becquerel/tools/materials.py
+++ b/becquerel/tools/materials.py
@@ -35,12 +35,11 @@ def _load_and_compile_materials():
             rho2 = data_elem["Density"][data_elem["Element"] == name].to_numpy()[0]
         elif name in data_mat["Material"].to_numpy():
             rho2 = data_mat["Density"][data_mat["Material"] == name].to_numpy()[0]
-        if rho2:
-            if not np.isclose(rho1, rho2, atol=2e-2):
-                raise MaterialsError(
-                    f"Material {name} densities do not match between different "
-                    f"data sources:  {rho1:.6f}  {rho2:.6f}"
-                )
+        if rho2 and not np.isclose(rho1, rho2, atol=2e-2):
+            raise MaterialsError(
+                f"Material {name} densities do not match between different "
+                f"data sources:  {rho1:.6f}  {rho2:.6f}"
+            )
 
     for j in range(len(data_comp)):
         name = data_comp["Material"].to_numpy()[j]

--- a/becquerel/tools/materials_compendium.py
+++ b/becquerel/tools/materials_compendium.py
@@ -66,7 +66,7 @@ def fetch_compendium_data():
         print("Pre-March 2022 JSON detected")
     elif isinstance(data, dict):
         print("Post-March 2022 JSON detected")
-        if "siteVersion" not in data.keys() or "data" not in data.keys():
+        if "siteVersion" not in data or "data" not in data:
             raise MaterialsError(
                 "Attempt to read Compendium JSON failed; "
                 "dictionary must have keys 'siteVersion' "
@@ -80,7 +80,7 @@ def fetch_compendium_data():
             "object must be a list or dict but is a " + str(type(data))
         )
     names = [datum["Name"] for datum in data]
-    formulae = [datum["Formula"] if "Formula" in datum else "-" for datum in data]
+    formulae = [datum.get("Formula", "-") for datum in data]
     densities = [datum["Density"] for datum in data]
     weight_fracs = [
         json_elements_to_weight_fractions(datum["Elements"]) for datum in data

--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -262,9 +262,7 @@ def _parse_float_uncertainty(x, dx):
     # handle blank or missing data
     if x == "" or x == " ":
         return None
-    if "****" in dx:
-        dx = ""
-    elif dx in ["LT", "GT", "LE", "GE", "AP", "CA", "SY"]:
+    if "****" in dx or dx in ["LT", "GT", "LE", "GE", "AP", "CA", "SY"]:
         dx = ""
     try:
         x2 = float(x)
@@ -408,9 +406,7 @@ class _NNDCQuery:
 
     def __len__(self):
         """Length of any one of the data lists."""
-        if self.df is None:
-            return 0
-        elif len(self.df.keys()) == 0:
+        if self.df is None or len(self.df.keys()) == 0:
             return 0
         else:
             return len(self.df[self.df.keys()[0]])

--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -122,7 +122,7 @@ def _parse_headers(headers):
     # reformat column headers if needed
     for j, hd in enumerate(headers):
         # rename so always have T1/2 (s)
-        if hd == "T1/2 (num)" or hd == "T1/2 (seconds)":
+        if hd in ("T1/2 (num)", "T1/2 (seconds)"):
             hd = "T1/2 (s)"
         # for uncertainties, add previous column header to it
         if j > 0 and "Unc" in hd:
@@ -260,7 +260,7 @@ def _parse_float_uncertainty(x, dx):
     if "8 .0E-E5" in x:
         x = x.replace("8 .0E-E5", "8.0E-5")
     # handle blank or missing data
-    if x == "" or x == " ":
+    if x in ("", " "):
         return None
     if "****" in dx or dx in ["LT", "GT", "LE", "GE", "AP", "CA", "SY"]:
         dx = ""

--- a/becquerel/tools/xcom.py
+++ b/becquerel/tools/xcom.py
@@ -178,9 +178,7 @@ class _XCOMQuery:
 
     def __len__(self):
         """Pass-through to use DataFrame len()."""
-        if self.df is None:
-            return 0
-        elif len(self.df.keys()) == 0:
+        if self.df is None or len(self.df.keys()) == 0:
             return 0
         else:
             return len(self.df[self.df.keys()[0]])

--- a/examples/isotopes.ipynb
+++ b/examples/isotopes.ipynb
@@ -173,7 +173,7 @@
    "source": [
     "for a in range(37, 44):\n",
     "    iso = Isotope(\"Potassium\", a)\n",
-    "    print(\"\")\n",
+    "    print()\n",
     "    print(f\"Isotope: {iso}\")\n",
     "    print(f\"Spin-parity: {iso.j_pi}\")\n",
     "    if iso.abundance is not None:\n",

--- a/examples/nndc.ipynb
+++ b/examples/nndc.ipynb
@@ -119,7 +119,7 @@
    "source": [
     "card = bq.tools.fetch_wallet_card(nuc=\"Cs-137\")\n",
     "display(card)\n",
-    "print(\"\")\n",
+    "print()\n",
     "t12 = max(card[\"T1/2 (s)\"])\n",
     "print(f\"{t12} s\")\n",
     "print(f\"{t12 / 3600 / 24 / 365.25} y\")"
@@ -233,7 +233,7 @@
     "    nuc=\"Cs-137\", type=\"Gamma\", i_range=(1, None), e_range=(661, 663)\n",
     ")\n",
     "display(rad)\n",
-    "print(\"\")\n",
+    "print()\n",
     "print(\n",
     "    \"{:.2f} keV line intensity: {}%\".format(\n",
     "        rad[\"Radiation Energy (keV)\"][0], rad[\"Radiation Intensity (%)\"][0]\n",

--- a/examples/nndc_chart_of_nuclides.ipynb
+++ b/examples/nndc_chart_of_nuclides.ipynb
@@ -17,9 +17,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib.patches as patches\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "from matplotlib import patches\n",
     "\n",
     "import becquerel as bq"
    ]

--- a/examples/overview.ipynb
+++ b/examples/overview.ipynb
@@ -1082,7 +1082,7 @@
    "source": [
     "for a in range(39, 42):\n",
     "    iso = bq.Isotope(\"Potassium\", a)\n",
-    "    print(\"\")\n",
+    "    print()\n",
     "    print(f\"Isotope: {iso}\")\n",
     "    print(f\"    Spin-parity: {iso.j_pi}\")\n",
     "    if iso.abundance is not None:\n",

--- a/examples/rebinning.ipynb
+++ b/examples/rebinning.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "\n",
     "def plot_rebin_spec(specs, lim=None):\n",
-    "    fig, ax = plt.subplots()\n",
+    "    _fig, ax = plt.subplots()\n",
     "    for s in specs:\n",
     "        s.plot(ax=ax)\n",
     "        s.fill_between(ax=ax, alpha=0.5)\n",

--- a/examples/spectrum.ipynb
+++ b/examples/spectrum.ipynb
@@ -478,7 +478,7 @@
     "\n",
     "bgsub = spec - bg\n",
     "print(f\"Total subtracted countrate: {np.sum(bgsub.cps):6.3f}\")\n",
-    "print(\"\")\n",
+    "print()\n",
     "print(\"In the K-40 peak:\")\n",
     "print(f\"Pottery counts: {spec.counts_vals[7990:7997]}\")\n",
     "print(f\"Pottery cps: {spec.cps_vals[7990:7997]}\")\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ select = [
   "RSE",     # flake8-raise
   # "RET",     # flake8-return
   # "SLF",     # flake8-self
-  # "SIM",     # flake8-simplify
+  "SIM",     # flake8-simplify
   # "TID",     # flake8-tidy-imports
   "TCH",     # flake8-type-checking
   "INT",     # flake8-gettext
@@ -83,6 +83,9 @@ ignore = [
   "B015",      # Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
   "B018",      # Found useless expression. Either assign it to a variable or remove it.
   "B028",      # No explicit `stacklevel` keyword argument found
+  "SIM105",    # Use `contextlib.suppress(Exception)` instead of `try`-`except`-`pass`
+  "SIM108",    # Use ternary operator instead of `if`-`else`-block
+  "SIM300",    # Yoda conditions are discouraged
   "PD901",     # Avoid using the generic variable name `df` for DataFrames
   "TRY003",    # Avoid specifying long messages outside the exception class
   "NPY002",    # Replace legacy `np.random.poisson` call with `np.random.Generator`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ ignore = [
   "PD901",     # Avoid using the generic variable name `df` for DataFrames
   "PLW1641",   # Object does not implement `__hash__` method
   "PLW2901",   # `for` loop variable overwritten by assignment target
-  "PLW3201",   # Bad or misspelled dunder method name
   "PLC1901",   # expression can be simplified as an empty string is falsey
   "PLC2701",   # Private name import from external module
   "PLR2004",   # Magic value used in comparison, consider replacing with a constant variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,14 @@ ignore = [
   "SIM108",    # Use ternary operator instead of `if`-`else`-block
   "SIM300",    # Yoda conditions are discouraged
   "PD901",     # Avoid using the generic variable name `df` for DataFrames
+  "PLW1641",   # Object does not implement `__hash__` method
   "PLW2901",   # `for` loop variable overwritten by assignment target
+  "PLW3201",   # Bad or misspelled dunder method name
+  "PLC1901",   # expression can be simplified as an empty string is falsey
+  "PLC2701",   # Private name import from external module
   "PLR2004",   # Magic value used in comparison, consider replacing with a constant variable
+  "PLR6201",   # Use a `set` literal when testing for membership
+  "PLR6301",   # Method could be a function, class method, or static method
   "TRY003",    # Avoid specifying long messages outside the exception class
   "NPY002",    # Replace legacy `np.random.poisson` call with `np.random.Generator`
   "PERF203",   # `try`-`except` within a loop incurs performance overhead
@@ -117,7 +123,8 @@ convention = "google"
 [tool.ruff.lint.pylint]
 max-args = 15
 max-branches = 60
-max-locals = 25
+max-locals = 35
 max-nested-blocks = 15
+max-public-methods = 60
 max-returns = 20
 max-statements = 150

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ select = [
   "FLY",     # flynt
   "NPY",     # NumPy-specific rules
   "PERF",    # Perflint
-  # "FURB",    # refurb
+  "FURB",    # refurb
   "RUF",     # Ruff-specific rules
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ select = [
   # "ERA",     # eradicate
   "PD",      # pandas-vet
   "PGH",     # pygrep-hooks
-  # "PL",      # pylint
+  "PL",      # pylint
   "TRY",     # tryceratops
   "FLY",     # flynt
   "NPY",     # NumPy-specific rules
@@ -87,6 +87,8 @@ ignore = [
   "SIM108",    # Use ternary operator instead of `if`-`else`-block
   "SIM300",    # Yoda conditions are discouraged
   "PD901",     # Avoid using the generic variable name `df` for DataFrames
+  "PLW2901",   # `for` loop variable overwritten by assignment target
+  "PLR2004",   # Magic value used in comparison, consider replacing with a constant variable
   "TRY003",    # Avoid specifying long messages outside the exception class
   "NPY002",    # Replace legacy `np.random.poisson` call with `np.random.Generator`
   "PERF203",   # `try`-`except` within a loop incurs performance overhead
@@ -114,7 +116,8 @@ convention = "google"
 
 [tool.ruff.lint.pylint]
 max-args = 15
-max-branches = 15
+max-branches = 60
 max-locals = 25
 max-nested-blocks = 15
-max-statements = 100
+max-returns = 20
+max-statements = 150

--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,16 @@ _spec.loader.exec_module(METADATA)
 site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 # remove package title from description
-with Path("README.md").open() as fh:
+with Path("README.md").open(encoding="utf-8") as fh:
     README = "\n".join(fh.readlines()[2:])
 
-with Path("CONTRIBUTING.md").open() as fh:
+with Path("CONTRIBUTING.md").open(encoding="utf-8") as fh:
     CONTRIBUTING = fh.read()
 
-with Path("requirements.txt").open() as fh:
+with Path("requirements.txt").open(encoding="utf-8") as fh:
     REQUIREMENTS = [_line for _line in fh if _line]
 
-with Path("requirements-dev.txt").open() as fh:
+with Path("requirements-dev.txt").open(encoding="utf-8") as fh:
     REQUIREMENTS_DEV = [line.strip() for line in fh if not line.startswith("-r")]
 
 # make long description from README and CONTRIBUTING

--- a/tests/fitting_test.py
+++ b/tests/fitting_test.py
@@ -31,7 +31,7 @@ def sim_data(x_min, x_max, y_func, num_x=200, binning="linear", **params):
         edges = np.linspace(x_min, x_max, num_x, dtype=float)
     elif binning == "sqrt":
         edges = np.linspace(np.sqrt(x_min), np.sqrt(x_max), num_x)
-        edges = edges**2
+        edges **= 2
     x = (edges[1:] + edges[:-1]) * 0.5
     dx = edges[1:] - edges[:-1]
 

--- a/tests/h5_tools_test.py
+++ b/tests/h5_tools_test.py
@@ -126,12 +126,12 @@ def check_dsets_attrs(dsets1, attrs1, dsets2, attrs2):
     """Check that the dataset and attribute dicts are identical."""
     assert set(dsets1.keys()) == set(dsets2.keys())
     assert set(attrs1.keys()) == set(attrs2.keys())
-    for key in dsets1.keys():
+    for key in dsets1:
         if "str" in key:
             assert ensure_string(dsets1[key]) == ensure_string(dsets2[key])
         else:
             assert np.allclose(dsets1[key], dsets2[key])
-    for key in attrs1.keys():
+    for key in attrs1:
         if "str" in key:
             assert ensure_string(attrs1[key]) == ensure_string(attrs2[key])
         else:

--- a/tests/materials_test.py
+++ b/tests/materials_test.py
@@ -7,12 +7,12 @@ from pathlib import Path
 import pytest
 from utils import xcom_is_up
 
-import becquerel.tools.materials as materials
-import becquerel.tools.materials_compendium as materials_compendium
 from becquerel.tools import (
     MaterialsError,
     MaterialsWarning,
     fetch_materials,
+    materials,
+    materials_compendium,
     remove_materials_csv,
 )
 from becquerel.tools.materials_nist import convert_composition

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -515,12 +515,12 @@ def test_errornone(uncal_spec):
     lines = 0
     for i in ax.get_children():
         if type(i) is mpl.collections.LineCollection:
-            colls = colls + 1
+            colls += 1
         if type(i) is mpl.collections.PolyCollection:
-            polys = polys + 1
+            polys += 1
 
         if type(i) is mpl.lines.Line2D:
-            lines = lines + 1
+            lines += 1
     assert colls == 0
     assert polys == 0
     assert lines == 1
@@ -536,9 +536,9 @@ def test_errorbars(uncal_spec):
     lines = 0
     for i in ax.get_children():
         if type(i) is mpl.collections.LineCollection:
-            colls = colls + 1
+            colls += 1
         if type(i) is mpl.lines.Line2D:
-            lines = lines + 1
+            lines += 1
     assert colls == 1
     assert lines >= 1
     plt.close("all")
@@ -553,9 +553,9 @@ def test_errorband(uncal_spec):
     lines = 0
     for i in ax.get_children():
         if type(i) is mpl.collections.PolyCollection:
-            colls = colls + 1
+            colls += 1
         if type(i) is mpl.lines.Line2D:
-            lines = lines + 1
+            lines += 1
     assert colls == 1
     assert lines == 1
     plt.close("all")

--- a/tests/wallet_cache_test.py
+++ b/tests/wallet_cache_test.py
@@ -5,7 +5,7 @@ import pytest
 import uncertainties
 from utils import nndc_is_up
 
-import becquerel.tools.wallet_cache as wallet_cache
+from becquerel.tools import wallet_cache
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR enables the following [rulesets](https://docs.astral.sh/ruff/rules/) in [`ruff`](https://docs.astral.sh/ruff/):

  - `SIM`: [flake8-simplify](https://pypi.org/project/flake8_simplify/) rules to simplify code
  - `PL`: [pylint](https://pypi.org/project/pylint/) rules to "check[] for errors, enforce[] a coding standard, look[] for [code smells](https://martinfowler.com/bliki/CodeSmell.html), and [] make suggestions about how the code could be refactored"
  - `FURB`: [refurb](https://pypi.org/project/refurb/), "for refurbishing and modernizing Python codebases"

I thought these made useful improvements and would be helpful for maintaining our code going forward.