### PR TITLE
add Spectrum.__eq__

### DIFF
--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -783,7 +783,7 @@ class Spectrum:
             self.bin_edges_raw, other.bin_edges_raw
         ):
             return False
-        return True  # noqa: SIM103
+        return True
 
     def __len__(self) -> int:
         """The number of bins in the spectrum.

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -783,7 +783,7 @@ class Spectrum:
             self.bin_edges_raw, other.bin_edges_raw
         ):
             return False
-        return True
+        return True  # noqa: SIM103
 
     def __len__(self) -> int:
         """The number of bins in the spectrum.

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -779,7 +779,7 @@ class Spectrum:
             self.bin_edges_kev, other.bin_edges_kev
         ):
             return False
-        if not self.is_calibrated and not np.array_equal(
+        if not self.is_calibrated and not np.array_equal(  # noqa: SIM103
             self.bin_edges_raw, other.bin_edges_raw
         ):
             return False

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -4,7 +4,6 @@ import datetime
 import warnings
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 from uncertainties import UFloat, unumpy
@@ -760,7 +759,7 @@ class Spectrum:
 
         return deepcopy(self)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Test if two Spectrum objects have the same spectral data."""
         if not isinstance(other, Spectrum):
             return False
@@ -771,9 +770,13 @@ class Spectrum:
             return False
         if not np.array_equal(self.counts_uncs, other.counts_uncs):
             return False
-        if self.is_calibrated and not np.array_equal(self.bin_edges_kev, other.bin_edges_kev):
+        if self.is_calibrated and not np.array_equal(
+            self.bin_edges_kev, other.bin_edges_kev
+        ):
             return False
-        if not self.is_calibrated and not np.array_equal(self.bin_edges_raw, other.bin_edges_raw):
+        if not self.is_calibrated and not np.array_equal(
+            self.bin_edges_raw, other.bin_edges_raw
+        ):
             return False
         return True
 

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -763,22 +763,7 @@ class Spectrum:
         """Test if two Spectrum objects have the same spectral data."""
         if not isinstance(other, Spectrum):
             return False
-        for k in ["start_time", "stop_time", "realtime", "livetime", "is_calibrated"]:
-            if getattr(self, k) != getattr(other, k):
-                return False
-        if not np.array_equal(self.counts_vals, other.counts_vals):
-            return False
-        if not np.array_equal(self.counts_uncs, other.counts_uncs):
-            return False
-        if self.is_calibrated and not np.array_equal(
-            self.bin_edges_kev, other.bin_edges_kev
-        ):
-            return False
-        if not self.is_calibrated and not np.array_equal(
-            self.bin_edges_raw, other.bin_edges_raw
-        ):
-            return False
-        return True
+        return self.__dict__ == other.__dict__
 
     def __len__(self) -> int:
         """The number of bins in the spectrum.

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -766,10 +766,16 @@ class Spectrum:
         for k in ["start_time", "stop_time", "realtime", "livetime", "is_calibrated"]:
             if getattr(self, k) != getattr(other, k):
                 return False
-        if not np.array_equal(self.counts_vals, other.counts_vals):
-            return False
-        if not np.array_equal(self.counts_uncs, other.counts_uncs):
-            return False
+        if self._counts is None:
+            if not np.array_equal(self.cps_vals, other.cps_vals):
+                return False
+            if not np.array_equal(self.cps_uncs, other.cps_uncs, equal_nan=True):
+                return False
+        if self._counts is not None:
+            if not np.array_equal(self.counts_vals, other.counts_vals):
+                return False
+            if not np.array_equal(self.counts_uncs, other.counts_uncs, equal_nan=True):
+                return False
         if self.is_calibrated and not np.array_equal(
             self.bin_edges_kev, other.bin_edges_kev
         ):

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -761,7 +761,7 @@ class Spectrum:
 
     def __eq__(self, other: object) -> bool:
         """Test if two Spectrum objects have the same spectral data."""
-        if not isinstance(other, Spectrum):
+        if not self.__class__ == other.__class__:
             return False
         return self.__dict__ == other.__dict__
 

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -763,7 +763,22 @@ class Spectrum:
         """Test if two Spectrum objects have the same spectral data."""
         if not self.__class__ == other.__class__:
             return False
-        return self.__dict__ == other.__dict__
+        for k in ["start_time", "stop_time", "realtime", "livetime", "is_calibrated"]:
+            if getattr(self, k) != getattr(other, k):
+                return False
+        if not np.array_equal(self.counts_vals, other.counts_vals):
+            return False
+        if not np.array_equal(self.counts_uncs, other.counts_uncs):
+            return False
+        if self.is_calibrated and not np.array_equal(
+            self.bin_edges_kev, other.bin_edges_kev
+        ):
+            return False
+        if not self.is_calibrated and not np.array_equal(
+            self.bin_edges_raw, other.bin_edges_raw
+        ):
+            return False
+        return True
 
     def __len__(self) -> int:
         """The number of bins in the spectrum.

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from uncertainties import UFloat, unumpy
@@ -758,6 +759,23 @@ class Spectrum:
         """
 
         return deepcopy(self)
+
+    def __eq__(self, other: Any) -> bool:
+        """Test if two Spectrum objects have the same spectral data."""
+        if not isinstance(other, Spectrum):
+            return False
+        for k in ["start_time", "stop_time", "realtime", "livetime", "is_calibrated"]:
+            if getattr(self, k) != getattr(other, k):
+                return False
+        if not np.array_equal(self.counts_vals, other.counts_vals):
+            return False
+        if not np.array_equal(self.counts_uncs, other.counts_uncs):
+            return False
+        if self.is_calibrated and not np.array_equal(self.bin_edges_kev, other.bin_edges_kev):
+            return False
+        if not self.is_calibrated and not np.array_equal(self.bin_edges_raw, other.bin_edges_raw):
+            return False
+        return True
 
     def __len__(self) -> int:
         """The number of bins in the spectrum.

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -68,8 +68,7 @@ def make_spec(t, lt=None, lam=TEST_COUNTS):
         return bq.Spectrum(cps=make_data(lam=lam), livetime=lt)
     elif t == "data":
         return make_data()
-    else:
-        return t
+    return t
 
 
 @pytest.fixture
@@ -640,6 +639,20 @@ def test_cpskev_errors(spec_data):
     spec = bq.Spectrum(spec_data, livetime=300.9)
     with pytest.raises(bq.UncalibratedError):
         spec.cpskev
+
+
+@pytest.mark.parametrize("spectype", ["uncal", "cal", "uncal_cps"])
+def test_eq(spectype):
+    spec0 = make_spec(spectype)
+    spec1 = spec0.copy()
+    assert spec0 == spec1
+
+    spec0.filename = "tmp0.h5"
+    spec1.filename = "tmp1.h5"
+    assert spec0 == spec1
+
+    spec1.bin_edges_kev /= 2
+    assert spec0 != spec1
 
 
 # ----------------------------------------------

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -641,7 +641,7 @@ def test_cpskev_errors(spec_data):
         spec.cpskev
 
 
-@pytest.mark.parametrize("spectype", ["uncal", "cal", "uncal_cps"])
+@pytest.mark.parametrize("spectype", ["uncal", "cal", "uncal_cps", "cal_cps"])
 def test_eq(spectype):
     spec0 = make_spec(spectype)
     spec1 = spec0.copy()
@@ -651,7 +651,10 @@ def test_eq(spectype):
     spec1.filename = "tmp1.h5"
     assert spec0 == spec1
 
-    spec1.bin_edges_kev /= 2
+    if spectype.startswith("cal"):
+        spec1.bin_edges_kev = spec1.bin_edges_kev / 2.0
+    elif spectype.startswith("uncal"):
+        spec1.bin_edges_raw = spec1.bin_edges_raw / 2.0
     assert spec0 != spec1
 
 


### PR DESCRIPTION
I noticed with some Spectrum I/O stuff that comparing Spectrum objects wasn't working correctly:
![image](https://github.com/user-attachments/assets/3d38bdb2-16ee-4fcf-b358-2d177fdfef5c)

This provides a custom `Spectrum.__eq__` method that checks only the relevant spectral data for equality, rather than attributes like filenames, which I guess is what happens when no `__eq__` method is provided.