### PR TITLE
handle infinite relative uncertainty

### DIFF
--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import warnings
 
@@ -1069,7 +1071,7 @@ class Fitter:
             raise FittingError(f"Unknown param: {param}")
         raise FittingError(f"Unknown backend: {self.backend}")
 
-    def param_unc(self, param) -> float:
+    def param_unc(self, param: str) -> float | None:
         """
         Fit error of fit parameter `param`
         """
@@ -1089,7 +1091,7 @@ class Fitter:
             raise FittingError(f"Unknown param: {param}")
         raise FittingError(f"Unknown backend: {self.backend}")
 
-    def param_rel_unc(self, param) -> float:
+    def param_rel_unc(self, param: str) -> float | None:
         """
         Relative error of fit parameter `param`
         """
@@ -1097,7 +1099,7 @@ class Fitter:
             return self.param_unc(param) / np.abs(self.param_val(param))
         return None
 
-    def param_val_and_unc(self, param: str) -> ufloat:
+    def param_val_and_unc(self, param: str) -> ufloat | None:
         """Value and fit uncertainty of `param`, as a ufloat."""
         if self.param_unc(param):
             return ufloat(self.param_val(param), self.param_unc(param))


### PR DESCRIPTION
`lmfit` [recently switched](https://github.com/lmfit/lmfit-py/pull/1009) to returning `float` relative uncertainty values rather than `np.float64`, causing `ZeroDivisionErrors` to be raised rather than giving `np.inf` for expressions that look like `1.0 / 0.0`. We should preserve the IEEE-754-like behavior here of returning infinity since some of our downstream packages rely on it and `lmfit` does not want to revert.