### PR TITLE
Fixes the huge amounts of warnings during testing

### DIFF
--- a/becquerel/core/calibration.py
+++ b/becquerel/core/calibration.py
@@ -378,8 +378,17 @@ def _fit_expression(
             f"Starting parameters have length {len(params0)}, but expression "
             f"requires {n_params} parameters"
         )
+    # Validate the initial expression over the fit data span rather than the
+    # full default domain when no explicit domain is given.
+    validation_domain = domain
+    if validation_domain is None and len(points_x) > 1 and points_x[0] < points_x[-1]:
+        validation_domain = (points_x[0], points_x[-1])
     expression = _validate_expression(
-        expression, params=params0, aux_params=aux_params, domain=domain, rng=rng
+        expression,
+        params=params0,
+        aux_params=aux_params,
+        domain=validation_domain,
+        rng=rng,
     )
 
     # check that we have enough points

--- a/becquerel/core/fitting.py
+++ b/becquerel/core/fitting.py
@@ -13,7 +13,7 @@ from lmfit.model import Model
 from lmfit.parameter import Parameters
 from matplotlib.font_manager import FontProperties
 from matplotlib.gridspec import GridSpec
-from uncertainties import ufloat
+from uncertainties import Variable, ufloat
 
 FWHM_SIG_RATIO = np.sqrt(8 * np.log(2))  # 2.35482
 SQRT_TWO = np.sqrt(2)  # 1.414213562
@@ -1232,7 +1232,7 @@ class Fitter:
         area_variance = area_variance[0, 0]
         # We don't divide by the binwidth here because we are summing bins: if we double
         # the binwidth, we double the counts per bin but halve the number of bins.
-        return ufloat(area, np.sqrt(area_variance))
+        return Variable(area, np.sqrt(area_variance))
 
     def param_val(self, param) -> float:
         """

--- a/becquerel/core/spectrum.py
+++ b/becquerel/core/spectrum.py
@@ -152,7 +152,7 @@ class Spectrum:
         if counts is not None:
             if len(counts) == 0:
                 raise SpectrumError("Empty spectrum counts")
-            if uncs is None and np.any(np.asarray(counts) < 0):
+            if uncs is None and np.any(np.asarray(unumpy.nominal_values(counts)) < 0):
                 raise SpectrumError(
                     "Negative values encountered in counts. Uncertainties "
                     "are most likely not Poisson-distributed. Provide uncs "

--- a/becquerel/core/utils.py
+++ b/becquerel/core/utils.py
@@ -103,7 +103,9 @@ def handle_datetime(input_time, error_name="datetime arg", allow_none=False):
         )
         return datetime.datetime(input_time.year, input_time.month, input_time.day)
     elif isinstance(input_time, Number):
-        return datetime.datetime.utcfromtimestamp(input_time)
+        return datetime.datetime.fromtimestamp(
+            input_time, datetime.timezone.utc
+        ).replace(tzinfo=None)
     elif isinstance(input_time, str):
         try:
             return dateutil_parse(input_time)

--- a/becquerel/parsers/cnf.py
+++ b/becquerel/parsers/cnf.py
@@ -32,7 +32,9 @@ def _convert_date(data, index):
     # to the start of the Unix epoch on 1 January 1970.
     d = _from_little_endian(data, index, 8)
     t = (d / 10000000.0) - 3506716800
-    return datetime.datetime.utcfromtimestamp(t)
+    return datetime.datetime.fromtimestamp(t, datetime.timezone.utc).replace(
+        tzinfo=None
+    )
 
 
 def _convert_time(data, index):

--- a/becquerel/tools/isotope_qty.py
+++ b/becquerel/tools/isotope_qty.py
@@ -6,6 +6,7 @@ import warnings
 from collections import OrderedDict
 
 import numpy as np
+from uncertainties import nominal_value
 
 from ..core import utils
 from .isotope import Isotope
@@ -202,7 +203,8 @@ class IsotopeQuantity:
         """
 
         val *= 1.0  # convert to float, or preserve ufloat, as appropriate
-        if val < 0:
+        val_nominal = nominal_value(val)
+        if val_nominal < 0:
             raise ValueError(f"Mass or activity must be a positive quantity: {val}")
         return val
 

--- a/becquerel/tools/nndc.py
+++ b/becquerel/tools/nndc.py
@@ -346,7 +346,7 @@ def _parse_float_uncertainty(x, dx):
         raise NNDCRequestError(
             f'Uncertainty cannot be parsed as float: "{dx}"'
         ) from exc
-    return uncertainties.ufloat(x2, dx2)
+    return uncertainties.Variable(x2, dx2)
 
 
 def _format_range(x_range):
@@ -599,6 +599,8 @@ class _NNDCQuery:
         self.df["M"] = [0] * len(self)
         # add string m giving the isomer level name (e.g., '' or 'm' or 'm2')
         self.df["m"] = [""] * len(self)
+        energy_levels = self["Energy Level (MeV)"]
+        energy_levels_nominal = energy_levels.map(uncertainties.nominal_value)
         # loop over each isotope in the dataframe
         A_Z = list(zip(self["A"], self["Z"]))
         A_Z = set(A_Z)
@@ -606,17 +608,13 @@ class _NNDCQuery:
             isotope = (self["A"] == a) & (self["Z"] == z)
             e_levels = []
             e_levels_nominal = []
-            for e_level in self["Energy Level (MeV)"][isotope]:
-                if isinstance(e_level, uncertainties.core.Variable):
-                    e_level_nominal = e_level.nominal_value
-                else:
-                    e_level_nominal = e_level
+            for e_level_nominal in energy_levels_nominal[isotope]:
                 if e_level_nominal not in e_levels_nominal:
-                    e_levels.append(e_level)
+                    e_levels.append(e_level_nominal)
                     e_levels_nominal.append(e_level_nominal)
             e_levels = sorted(e_levels)
             for M, e_level in enumerate(e_levels):
-                isomer = isotope & (abs(self["Energy Level (MeV)"] - e_level) < 1e-10)
+                isomer = isotope & (np.abs(energy_levels_nominal - e_level) < 1e-10)
                 self.df.loc[isomer, "M"] = M
                 if M > 0:
                     if len(e_levels) > 2:
@@ -937,7 +935,8 @@ class _NuclearWalletCardQuery(_NNDCQuery):
                 value = quantity["value"] * scale
                 uncertainty = quantity.get("uncertainty", {})
                 if uncertainty.get("type") == "symmetric":
-                    return uncertainties.ufloat(value, uncertainty["value"] * scale)
+                    uncertainty_value = uncertainty["value"] * scale
+                    return uncertainties.Variable(value, uncertainty_value)
                 return value
             return quantity * scale
 
@@ -1151,7 +1150,7 @@ def fetch_decay_radiation(**kwargs):
 
     query = _DecayRadiationQuery(**kwargs)
     # apply elevel_range filter (hack around the web API)
-    elevel = query.df["Energy Level (MeV)"]
+    elevel = query.df["Energy Level (MeV)"].map(uncertainties.nominal_value)
     keep = (elevel >= query.elevel_range[0]) & (elevel <= query.elevel_range[1])
     query.df = query.df[keep]
     return query.df

--- a/becquerel/tools/wallet_cache.py
+++ b/becquerel/tools/wallet_cache.py
@@ -16,7 +16,9 @@ def convert_float_ufloat(x):
     if isinstance(x, str):
         if "+/-" in x:
             tokens = x.split("+/-")
-            return uncertainties.ufloat(float(tokens[0]), float(tokens[1]))
+            nominal = float(tokens[0])
+            std_dev = float(tokens[1])
+            return uncertainties.Variable(nominal, std_dev)
         if x == "":
             return None
     return float(x)

--- a/tests/calibration_test.py
+++ b/tests/calibration_test.py
@@ -289,6 +289,20 @@ domain = [0, 3500]
 rng = [0, 1000]
 
 
+def fit_kwargs(name):
+    """Keep nonlinear fit tests inside their valid parameter regions."""
+    if name in {"cal3", "sqrt2"}:
+        return {"bounds": ([0.0, 0.0, 0.0], [np.inf, np.inf, np.inf])}
+    if name == "cal4":
+        return {
+            "bounds": (
+                [-np.inf, -np.inf, -np.inf, 1e-12],
+                [np.inf, np.inf, np.inf, np.inf],
+            )
+        }
+    return {}
+
+
 def make_calibration(name, args):
     """Make an instance of the desired Calibration type."""
     attrs = {"comment": "Test of Calibration class", "name": name}
@@ -382,19 +396,20 @@ def test_calibration_set_add_points(name, args):
 @pytest.mark.parametrize("name, args", name_args)
 def test_calibration_fit_from_points(name, args):
     """Test Calibration.fit and from_points methods."""
+    kwargs = fit_kwargs(name)
     # test fit()
     cal1 = make_calibration(name, args)
     cal1.add_points(points_x, points_y)
-    cal1.fit()
+    cal1.fit(**kwargs)
     # alternate: call fit_points() instead of add_points() and fit()
-    cal1.fit_points(points_x, points_y)
+    cal1.fit_points(points_x, points_y, **kwargs)
 
     # skip any instances that require a factory method
     if len(args) != 2:
         cal2 = None
     else:
         # test from_points()
-        cal2 = Calibration.from_points(args[0], points_x, points_y)
+        cal2 = Calibration.from_points(args[0], points_x, points_y, fit_kwargs=kwargs)
         cal2 = Calibration.from_points(
             args[0],
             points_x,
@@ -402,22 +417,25 @@ def test_calibration_fit_from_points(name, args):
             params0=args[1],
             domain=cal1.domain,
             rng=cal1.range,
+            fit_kwargs=kwargs,
         )
         assert cal2 == cal1
 
     # test fit() with weights
     cal1 = make_calibration(name, args)
     cal1.add_points(points_x, points_y, weights)
-    cal1.fit()
+    cal1.fit(**kwargs)
     # alternate: call fit_points() with weights
-    cal1.fit_points(points_x, points_y, weights)
+    cal1.fit_points(points_x, points_y, weights, **kwargs)
 
     # skip any instances that require a factory method
     if len(args) != 2:
         cal2 = None
     else:
         # test from_points() with weights
-        cal2 = Calibration.from_points(args[0], points_x, points_y, weights)
+        cal2 = Calibration.from_points(
+            args[0], points_x, points_y, weights, fit_kwargs=kwargs
+        )
         cal2 = Calibration.from_points(
             args[0],
             points_x,
@@ -426,6 +444,7 @@ def test_calibration_fit_from_points(name, args):
             params0=args[1],
             domain=cal1.domain,
             rng=cal1.range,
+            fit_kwargs=kwargs,
         )
         assert cal2 == cal1
 

--- a/tests/isotope_qty_test.py
+++ b/tests/isotope_qty_test.py
@@ -3,6 +3,7 @@ import datetime
 
 import numpy as np
 import pytest
+import uncertainties
 from dateutil.parser import parse as dateutil_parse
 from uncertainties import ufloat
 
@@ -23,6 +24,8 @@ from becquerel.tools.isotope_qty import (
 
 def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
     """function to work with uncertainties too."""
+    a = uncertainties.nominal_value(a)
+    b = uncertainties.nominal_value(b)
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 

--- a/tests/nndc_test.py
+++ b/tests/nndc_test.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from uncertainties import unumpy
 from utils import nndc_is_up
 
 from becquerel.tools import nndc
@@ -10,17 +11,8 @@ from becquerel.tools import nndc
 
 def ufloats_overlap_range(ufloats, vmin, vmax):
     """Return whether the +/- 1 sigma range overlaps the value range."""
-    vals = []
-    sigmas = []
-    for val in ufloats:
-        if isinstance(val, float):
-            vals.append(val)
-            sigmas.append(0)
-        else:
-            vals.append(val.nominal_value)
-            sigmas.append(val.std_dev)
-    vals = np.array(vals)
-    sigmas = np.array(sigmas)
+    vals = unumpy.nominal_values(ufloats)
+    sigmas = unumpy.std_devs(ufloats)
     return ((vals - sigmas <= vmax) | (vals + sigmas >= vmin)).all()
 
 
@@ -415,35 +407,36 @@ class NNDCQueryTests:
         d = self.fetch(z_range=(9, 10), t_range=(None, 1e4))
         assert len(d) > 0
         assert ((9 <= d.Z) & (d.Z <= 10)).all()
-        assert (d["T1/2 (s)"] <= 1e4).all()
+        assert (unumpy.nominal_values(d["T1/2 (s)"]) <= 1e4).all()
 
     def test_query_zrange_9_10_trange_0_1E4(self):
         """Test NNDCQuery: z_range=(9, 10), t_range=(0, 1e4)..............."""
         d = self.fetch(z_range=(9, 10), t_range=(0, 1e4))
         assert len(d) > 0
         assert ((9 <= d.Z) & (d.Z <= 10)).all()
-        assert (d["T1/2 (s)"] <= 1e4).all()
+        assert (unumpy.nominal_values(d["T1/2 (s)"]) <= 1e4).all()
 
     def test_query_zrange_9_10_trange_1E3_1E9(self):
         """Test NNDCQuery: z_range=(9, 10), t_range=(1e3, 1e9)............."""
         d = self.fetch(z_range=(9, 10), t_range=(1e3, 1e9))
         assert len(d) > 0
         assert ((9 <= d.Z) & (d.Z <= 10)).all()
-        assert ((1e3 <= d["T1/2 (s)"]) & (d["T1/2 (s)"] <= 1e9)).all()
+        half_lives = unumpy.nominal_values(d["T1/2 (s)"])
+        assert ((1e3 <= half_lives) & (half_lives <= 1e9)).all()
 
     def test_query_zrange_5_10_trange_1E9_None(self):
         """Test NNDCQuery: z_range=(5, 10), t_range=(1e9, None)............"""
         d = self.fetch(z_range=(5, 10), t_range=(1e9, None))
         assert len(d) > 0
         assert ((5 <= d.Z) & (d.Z <= 10)).all()
-        assert (d["T1/2 (s)"] >= 1e9).all()
+        assert (unumpy.nominal_values(d["T1/2 (s)"]) >= 1e9).all()
 
     def test_query_zrange_5_10_trange_1E9_inf(self):
         """Test NNDCQuery: z_range=(5, 10), t_range=(1e9, np.inf).........."""
         d = self.fetch(z_range=(5, 10), t_range=(1e9, np.inf))
         assert len(d) > 0
         assert ((5 <= d.Z) & (d.Z <= 10)).all()
-        assert (d["T1/2 (s)"] >= 1e9).all()
+        assert (unumpy.nominal_values(d["T1/2 (s)"]) >= 1e9).all()
 
     def test_query_nuc_Pu239_decay_ANY(self):
         """Test NNDCQuery: nuc='Pu-239', decay='ANY'......................."""
@@ -726,7 +719,7 @@ class TestDecayRadiationQuery(NNDCQueryTests):
         assert len(d) == 0
         assert (d.Z == 91).all()
         assert (d.A == 234).all()
-        assert (d["Energy Level (MeV)"] > 0).all()
+        assert (unumpy.nominal_values(d["Energy Level (MeV)"]) > 0).all()
 
     def test_decay_zrange_230_250(self):
         """Test fetch_decay_radiation: z_range=(230, 250) dataframe empty.."""


### PR DESCRIPTION
So far this pull request addresses 3 main points in the testing suite:

1) uncertainty package made a few questionable decisions. It raises a warning for example for every `ufloat(number, 0)` call, this is fixed by moving to `Variable(number, 0)`. Values with uncertainties also don't like being compared. This is all addressed
2) There were some outdate timezone calls. That is fixed too
3) Calibration runs into some invalid values sometimes. This adds better bounds to the tests and restricts the region where we verify the fit initially. @markbandstra Happy to get some feedback if that is a good approach.