### PR TITLE
Raise ElementZError instead of leaking TypeError for non-numeric Z input

### DIFF
--- a/becquerel/tools/element.py
+++ b/becquerel/tools/element.py
@@ -183,7 +183,7 @@ def validated_z(z):
 
     try:
         int(z)
-    except ValueError as exc:
+    except (ValueError, TypeError) as exc:
         raise ElementZError(f'Element Z="{z}" invalid') from exc
     if int(z) not in ZS:
         raise ElementZError(f'Element Z="{z}" not found')

--- a/tests/element_test.py
+++ b/tests/element_test.py
@@ -186,3 +186,19 @@ class TestElementStrFormat:
     def test_og(self):
         """Test Element string formatting: Og.............................."""
         assert "{:%n (%s) %z}".format(element.Element("Og")) == "Oganesson (Og) 118"
+
+
+class TestElementBadTypeInput:
+    """Non-convertible types should raise the documented element errors."""
+
+    @pytest.mark.parametrize("bad", [None, [1], {}, (1, 2)])
+    def test_validated_z_bad_type(self, bad):
+        """Test validated_z(non-convertible type) raises ElementZError....."""
+        with pytest.raises(element.ElementZError):
+            element.validated_z(bad)
+
+    @pytest.mark.parametrize("bad", [None, [1], {}])
+    def test_element_init_bad_type(self, bad):
+        """Test Element(non-convertible type) raises ElementError.........."""
+        with pytest.raises(element.ElementError):
+            element.Element(bad)


### PR DESCRIPTION
I was reading through tools/element.py and noticed validated_z can leak a TypeError.

The docstring says it raises ElementZError if z cannot be converted to an integer, but int(z) raises TypeError (not ValueError) for things like None, a list, or a dict, and only ValueError is caught. So validated_z(None) raises a bare TypeError, and because Element() falls through to _init_z, Element(None) raises TypeError too instead of the ElementError its docstring promises. The same leak reaches element_symbol/element_name and Isotope.

validated_symbol and validated_name right below already handle the bad-type case (they wrap .lower() in try/except AttributeError). This just lines validated_z up with them by also catching TypeError.

Added a couple of parametrized tests for None/list/dict input on both validated_z and Element. The existing element tests still pass.
